### PR TITLE
Blake3 Perf Enhancements

### DIFF
--- a/HashLib/src/Crypto/HlpBlake3.pas
+++ b/HashLib/src/Crypto/HlpBlake3.pas
@@ -88,10 +88,7 @@ type
       class function DefaultBlake3Node(): TBlake3Node; static;
 
     public
-      class function CreateBlake3Node(const ACV, ABlock: THashLibUInt32Array;
-        ACounter: UInt64; ABlockLen, AFlags: UInt32): TBlake3Node; static;
-
-      class function ParentNode(const ALeft, ARight, AKey: THashLibUInt32Array;
+      class function ParentNode(ALeft, ARight, AKey: PCardinal;
         AFlags: UInt32): TBlake3Node; static;
     end;
 
@@ -122,7 +119,7 @@ type
       class function DefaultBlake3ChunkState(): TBlake3ChunkState; static;
 
     public
-      class function CreateBlake3ChunkState(const AIV: THashLibUInt32Array;
+      class function CreateBlake3ChunkState(AIV: PCardinal;
         AChunkCounter: UInt64; AFlags: UInt32): TBlake3ChunkState; static;
     end;
 
@@ -150,7 +147,7 @@ type
   function HasSubTreeAtHeight(AIdx: Int32): Boolean; inline;
 
   // AddChunkChainingValue appends a chunk to the right edge of the Merkle tree.
-  procedure AddChunkChainingValue(const ACV: THashLibUInt32Array); inline;
+  procedure AddChunkChainingValue(ACV: PCardinal); inline;
 
   class function Len64(AValue: UInt64): Int32; static;
 
@@ -160,12 +157,12 @@ type
   var
     FCS: TBlake3ChunkState;
     FOutputReader: TBlake3OutputReader;
-    FKey: THashLibUInt32Array;
+    FKey: array [0 .. 7] of UInt32;
     FFlags: UInt32;
 
     // log(n) set of Merkle subtree roots, at most one per height.
     // stack [54][8]uint32
-    FStack: THashLibMatrixUInt32Array; // 2^54 * chunkSize = 2^64
+    FStack: array [0 .. 53, 0 .. 7] of UInt32; // 2^54 * chunkSize = 2^64
     // bit vector indicating which stack elems are valid; also number of chunks added
     FUsed: UInt64;
 
@@ -179,7 +176,7 @@ type
       const AKey: THashLibByteArray); overload;
 
     constructor CreateInternal(AHashSize: Int32;
-      const AKeyWords: THashLibUInt32Array; AFlags: UInt32);
+      AKeyWords: PCardinal; AFlags: UInt32);
 
   public
     constructor Create(AHashSize: THashSize = THashSize.hsHashSize256;
@@ -230,7 +227,7 @@ type
     constructor Create(AHashSize: Int32;
       const AKey: THashLibByteArray); overload;
 
-    constructor Create(AHashSize: Int32; const AKeyWords: THashLibUInt32Array;
+    constructor Create(AHashSize: Int32; AKeyWords: PCardinal;
       AFlags: UInt32); overload;
 
     procedure Initialize(); override;
@@ -257,19 +254,6 @@ begin
   Result.Counter := 0;
   Result.BlockLen := 0;
   Result.Flags := 0;
-end;
-
-class function TBlake3.TBlake3Node.CreateBlake3Node(const ACV,
-  ABlock: THashLibUInt32Array; ACounter: UInt64; ABlockLen, AFlags: UInt32)
-  : TBlake3Node;
-begin
-  Result := DefaultBlake3Node();
-  System.Move(ACV[0], Result.CV, System.Length(ACV) * System.SizeOf(UInt32));
-  System.Move(ABlock[0], Result.Block, System.Length(ABlock) *
-    System.SizeOf(UInt32));
-  Result.Counter := ACounter;
-  Result.BlockLen := ABlockLen;
-  Result.Flags := AFlags;
 end;
 
 function TBlake3.TBlake3Node.Clone: TBlake3Node;
@@ -301,14 +285,16 @@ begin
   System.Move(LFull, AResult[0], 8 * System.SizeOf(UInt32));
 end;
 
-class function TBlake3.TBlake3Node.ParentNode(const ALeft, ARight,
-  AKey: THashLibUInt32Array; AFlags: UInt32): TBlake3Node;
-var
-  LBlockWords: THashLibUInt32Array;
+class function TBlake3.TBlake3Node.ParentNode(ALeft, ARight,
+  AKey: PCardinal; AFlags: UInt32): TBlake3Node;
 begin
-  LBlockWords := TArrayUtils.Concatenate(ALeft, ARight);
-  Result := TBlake3Node.CreateBlake3Node(AKey, LBlockWords, 0, BlockSizeInBytes,
-    AFlags or FlagParent);
+  Result := DefaultBlake3Node();
+  System.Move(AKey^, Result.CV[0], 8 * System.SizeOf(UInt32));
+  System.Move(ALeft^, Result.Block[0], 8 * System.SizeOf(UInt32));
+  System.Move(ARight^, Result.Block[8], 8 * System.SizeOf(UInt32));
+  Result.Counter := 0;
+  Result.BlockLen := BlockSizeInBytes;
+  Result.Flags := AFlags or FlagParent;
 end;
 
 { TBlake3.TBlake3ChunkState }
@@ -328,12 +314,11 @@ begin
 end;
 
 class function TBlake3.TBlake3ChunkState.CreateBlake3ChunkState
-  (const AIV: THashLibUInt32Array; AChunkCounter: UInt64; AFlags: UInt32)
+  (AIV: PCardinal; AChunkCounter: UInt64; AFlags: UInt32)
   : TBlake3ChunkState;
 begin
   Result := DefaultBlake3ChunkState;
-  System.Move(AIV[0], Result.N.CV[0], System.Length(AIV) *
-    System.SizeOf(UInt32));
+  System.Move(AIV^, Result.N.CV[0], 8 * System.SizeOf(UInt32));
   Result.N.Counter := AChunkCounter;
   Result.N.BlockLen := BlockSizeInBytes;
   // compress the first block with the start flag set
@@ -531,30 +516,22 @@ begin
 end;
 
 constructor TBlake3.CreateInternal(AHashSize: Int32;
-  const AKeyWords: THashLibUInt32Array; AFlags: UInt32);
-var
-  LIdx: Int32;
+  AKeyWords: PCardinal; AFlags: UInt32);
 begin
   inherited Create(AHashSize, BlockSizeInBytes);
-  FKey := System.Copy(AKeyWords);
+  System.Move(AKeyWords^, FKey[0], 8 * System.SizeOf(UInt32));
   FFlags := AFlags;
-  System.SetLength(FStack, 54);
-  for LIdx := System.Low(FStack) to System.High(FStack) do
-  begin
-    System.SetLength(FStack[LIdx], 8);
-  end;
 end;
 
 constructor TBlake3.Create(AHashSize: Int32; const AKey: THashLibByteArray);
 var
-  LKeyWords: THashLibUInt32Array;
+  LKeyWords: array [0 .. 7] of UInt32;
   LKeyLength: Int32;
 begin
-  System.SetLength(LKeyWords, 8);
   if AKey = nil then
   begin
     System.Move(IV, LKeyWords[0], System.SizeOf(IV));
-    CreateInternal(AHashSize, LKeyWords, 0);
+    CreateInternal(AHashSize, @LKeyWords[0], 0);
   end
   else
   begin
@@ -564,8 +541,8 @@ begin
       raise EArgumentOutOfRangeHashLibException.CreateResFmt(@SInvalidKeyLength,
         [KeyLengthInBytes, LKeyLength]);
     end;
-    TConverters.le32_copy(PByte(AKey), 0, PCardinal(LKeyWords), 0, LKeyLength);
-    CreateInternal(AHashSize, LKeyWords, FlagKeyedHash);
+    TConverters.le32_copy(PByte(AKey), 0, @LKeyWords[0], 0, LKeyLength);
+    CreateInternal(AHashSize, @LKeyWords[0], FlagKeyedHash);
   end;
 end;
 
@@ -576,9 +553,9 @@ end;
 
 procedure TBlake3.Initialize;
 begin
-  FCS := TBlake3ChunkState.CreateBlake3ChunkState(FKey, 0, FFlags);
+  FCS := TBlake3ChunkState.CreateBlake3ChunkState(@FKey[0], 0, FFlags);
   FOutputReader := TBlake3OutputReader.DefaultBlake3OutputReader();
-  TArrayUtils.ZeroFill(FStack);
+  FillChar(FStack, System.SizeOf(FStack), 0);
   FUsed := 0;
 end;
 
@@ -592,10 +569,10 @@ function TBlake3.Clone: IHash;
 var
   LHashInstance: TBlake3;
 begin
-  LHashInstance := TBlake3.CreateInternal(HashSize, FKey, FFlags);
+  LHashInstance := TBlake3.CreateInternal(HashSize, @FKey[0], FFlags);
   LHashInstance.FCS := FCS.Clone();
   LHashInstance.FOutputReader := FOutputReader.Clone();
-  LHashInstance.FStack := TArrayUtils.Clone(FStack);
+  System.Move(FStack, LHashInstance.FStack, System.SizeOf(FStack));
   LHashInstance.FUsed := FUsed;
   Result := LHashInstance;
   Result.BufferSize := BufferSize;
@@ -616,37 +593,30 @@ begin
   Result := (FUsed and (1 shl AIdx)) <> 0;
 end;
 
-procedure TBlake3.AddChunkChainingValue(const ACV: THashLibUInt32Array);
+procedure TBlake3.AddChunkChainingValue(ACV: PCardinal);
 var
   LIdx: Int32;
-  LFlags: UInt32;
-  LKey: THashLibUInt32Array;
-  LPtrCV: PCardinal;
 begin
-  LKey := FKey;
-  LFlags := FFlags;
-  LPtrCV := PCardinal(ACV);
   // seek to first open stack slot, merging subtrees as we go
   LIdx := 0;
   while HasSubTreeAtHeight(LIdx) do
   begin
-    TBlake3Node.ParentNode(FStack[LIdx], ACV, LKey, LFlags)
-      .ChainingValue(LPtrCV);
+    TBlake3Node.ParentNode(@FStack[LIdx, 0], ACV, @FKey[0], FFlags)
+      .ChainingValue(ACV);
     System.Inc(LIdx);
   end;
-  FStack[LIdx] := System.Copy(ACV);
+  System.Move(ACV^, FStack[LIdx, 0], 8 * System.SizeOf(UInt32));
   System.Inc(FUsed);
 end;
 
 function TBlake3.RootNode: TBlake3Node;
 var
   LIdx, LTrailingZeros64, LLen64: Int32;
-  LTemp: THashLibUInt32Array;
+  LTemp: array [0 .. 7] of UInt32;
   LPtrTemp: PCardinal;
 begin
   Result := FCS.Node();
-  System.SetLength(LTemp, 8);
-  LPtrTemp := PCardinal(LTemp);
+  LPtrTemp := @LTemp[0];
 
   LTrailingZeros64 := TrailingZeros64(FUsed);
   LLen64 := Len64(FUsed);
@@ -655,7 +625,8 @@ begin
     if HasSubTreeAtHeight(LIdx) then
     begin
       Result.ChainingValue(LPtrTemp);
-      Result := TBlake3Node.ParentNode(FStack[LIdx], LTemp, FKey, FFlags);
+      Result := TBlake3Node.ParentNode(@FStack[LIdx, 0], LPtrTemp,
+        @FKey[0], FFlags);
     end;
   end;
   Result.Flags := Result.Flags or FlagRoot;
@@ -665,27 +636,60 @@ procedure TBlake3.TransformBytes(const AData: THashLibByteArray;
   AIndex, ADataLength: Int32);
 var
   LPtrAData: PByte;
-  LCV: THashLibUInt32Array;
-  LCount: Int32;
+  LCV: array [0 .. 7] of UInt32;
+  LCVs: array [0 .. 7, 0 .. 7] of UInt32;
+  LCount, LParDeg, I, LBatchBytes: Int32;
   LPtrCV: PCardinal;
 begin
   LPtrAData := PByte(AData) + AIndex;
-  System.SetLength(LCV, 8);
-  LPtrCV := PCardinal(LCV);
+  LPtrCV := @LCV[0];
+  LParDeg := Blake3_ParallelDegree;
+  LBatchBytes := LParDeg * ChunkSize;
 
+  // Step 1: Complete any partial chunk to reach a clean boundary
+  if (FCS.BytesConsumed > 0) and (ADataLength > 0) then
+  begin
+    LCount := Min(ChunkSize - FCS.BytesConsumed, ADataLength);
+    FCS.Update(LPtrAData, LCount);
+    System.Inc(LPtrAData, LCount);
+    System.Dec(ADataLength, LCount);
+  end;
+
+  // Flush the completed chunk if there's more data to process
+  if FCS.Complete() and (ADataLength > 0) then
+  begin
+    FCS.Node().ChainingValue(LPtrCV);
+    AddChunkChainingValue(LPtrCV);
+    FCS := TBlake3ChunkState.CreateBlake3ChunkState(@FKey[0],
+      FCS.ChunkCounter() + 1, FFlags);
+  end;
+
+  // Step 2: Process full chunk batches in parallel (4x SSE2, 8x AVX2)
+  // At this point FCS.BytesConsumed = 0 whenever ADataLength > 0.
+  // Always leave at least ChunkSize bytes for the sequential path so that
+  // the last chunk ends up in FCS (required by RootNode's invariant).
+  while ADataLength >= LBatchBytes + ChunkSize do
+  begin
+    Blake3_HashMany(LPtrAData, @FKey[0], @LCVs[0, 0],
+      LParDeg, FCS.ChunkCounter(), FFlags);
+    for I := 0 to LParDeg - 1 do
+      AddChunkChainingValue(@LCVs[I, 0]);
+    FCS := TBlake3ChunkState.CreateBlake3ChunkState(@FKey[0],
+      FCS.ChunkCounter() + UInt64(LParDeg), FFlags);
+    System.Inc(LPtrAData, LBatchBytes);
+    System.Dec(ADataLength, LBatchBytes);
+  end;
+
+  // Step 3: Process remaining data sequentially
   while ADataLength > 0 do
   begin
-    // If the current chunk is complete, finalize it and add it to the tree,
-    // then reset the chunk state (but keep incrementing the counter across
-    // chunks).
     if FCS.Complete() then
     begin
       FCS.Node().ChainingValue(LPtrCV);
-      AddChunkChainingValue(LCV);
-      FCS := TBlake3ChunkState.CreateBlake3ChunkState(FKey,
+      AddChunkChainingValue(LPtrCV);
+      FCS := TBlake3ChunkState.CreateBlake3ChunkState(@FKey[0],
         FCS.ChunkCounter() + 1, FFlags);
     end;
-    // Compress input bytes into the current chunk state.
     LCount := Min(ChunkSize - FCS.BytesConsumed, ADataLength);
     FCS.Update(LPtrAData, LCount);
     System.Inc(LPtrAData, LCount);
@@ -709,20 +713,19 @@ class procedure TBlake3.DeriveKey(const ASrcKey, ACtx,
 const
   derivationIVLen = Int32(32);
 var
-  LIVWords: THashLibUInt32Array;
+  LIVWords: array [0 .. 7] of UInt32;
   LDerivationIV: THashLibByteArray;
   LXof: IXOF;
 begin
-  System.SetLength(LIVWords, 8);
   System.Move(IV, LIVWords[0], System.SizeOf(IV));
   // construct the derivation Hasher and get the DerivationIV
-  LDerivationIV := (TBlake3.CreateInternal(derivationIVLen, LIVWords,
+  LDerivationIV := (TBlake3.CreateInternal(derivationIVLen, @LIVWords[0],
     FlagDeriveKeyContext) as IHash).ComputeBytes(ACtx).GetBytes();
-  TConverters.le32_copy(PByte(LDerivationIV), 0, PCardinal(LIVWords), 0,
+  TConverters.le32_copy(PByte(LDerivationIV), 0, @LIVWords[0], 0,
     KeyLengthInBytes);
 
   // derive the SubKey
-  LXof := TBlake3XOF.Create(32, LIVWords, FlagDeriveKeyMaterial);
+  LXof := TBlake3XOF.Create(32, @LIVWords[0], FlagDeriveKeyMaterial);
   LXof.XOFSizeInBits := System.Length(ASubKey) * 8;
   LXof.Initialize;
   LXof.TransformBytes(ASrcKey);
@@ -758,10 +761,10 @@ begin
   // Internal Blake3 Cloning
   LHashInstance.FCS := FCS.Clone();
   LHashInstance.FOutputReader := FOutputReader.Clone();
-  LHashInstance.FStack := TArrayUtils.Clone(FStack);
+  System.Move(FStack, LHashInstance.FStack, System.SizeOf(FStack));
   LHashInstance.FUsed := FUsed;
   LHashInstance.FFlags := FFlags;
-  LHashInstance.FKey := System.Copy(FKey);
+  System.Move(FKey, LHashInstance.FKey, System.SizeOf(FKey));
 
   Result := LHashInstance;
   Result.BufferSize := BufferSize;
@@ -774,7 +777,7 @@ begin
 end;
 
 constructor TBlake3XOF.Create(AHashSize: Int32;
-  const AKeyWords: THashLibUInt32Array; AFlags: UInt32);
+  AKeyWords: PCardinal; AFlags: UInt32);
 begin
   inherited CreateInternal(AHashSize, AKeyWords, AFlags);
   FFinalized := False;

--- a/HashLib/src/Crypto/HlpBlake3.pas
+++ b/HashLib/src/Crypto/HlpBlake3.pas
@@ -638,13 +638,12 @@ var
   LPtrAData: PByte;
   LCV: array [0 .. 7] of UInt32;
   LCVs: array [0 .. 7, 0 .. 7] of UInt32;
-  LCount, LParDeg, I, LBatchBytes: Int32;
+  LCount, LParDeg, I, LBatchBytes, LNumChunks: Int32;
   LPtrCV: PCardinal;
 begin
   LPtrAData := PByte(AData) + AIndex;
   LPtrCV := @LCV[0];
   LParDeg := Blake3_ParallelDegree;
-  LBatchBytes := LParDeg * ChunkSize;
 
   // Step 1: Complete any partial chunk to reach a clean boundary
   if (FCS.BytesConsumed > 0) and (ADataLength > 0) then
@@ -668,14 +667,19 @@ begin
   // At this point FCS.BytesConsumed = 0 whenever ADataLength > 0.
   // Always leave at least ChunkSize bytes for the sequential path so that
   // the last chunk ends up in FCS (required by RootNode's invariant).
-  while ADataLength >= LBatchBytes + ChunkSize do
+  // HashMany cascades internally (e.g. AVX2: hash8 -> hash4 -> scalar).
+  while ADataLength >= 2 * ChunkSize do
   begin
+    LNumChunks := (ADataLength div ChunkSize) - 1;
+    if LNumChunks > LParDeg then
+      LNumChunks := LParDeg;
     Blake3_HashMany(LPtrAData, @FKey[0], @LCVs[0, 0],
-      LParDeg, FCS.ChunkCounter(), FFlags);
-    for I := 0 to LParDeg - 1 do
+      LNumChunks, FCS.ChunkCounter(), FFlags);
+    for I := 0 to LNumChunks - 1 do
       AddChunkChainingValue(@LCVs[I, 0]);
+    LBatchBytes := LNumChunks * ChunkSize;
     FCS := TBlake3ChunkState.CreateBlake3ChunkState(@FKey[0],
-      FCS.ChunkCounter() + UInt64(LParDeg), FFlags);
+      FCS.ChunkCounter() + UInt64(LNumChunks), FFlags);
     System.Inc(LPtrAData, LBatchBytes);
     System.Dec(ADataLength, LBatchBytes);
   end;

--- a/HashLib/src/Crypto/HlpBlake3Dispatch.pas
+++ b/HashLib/src/Crypto/HlpBlake3Dispatch.pas
@@ -625,6 +625,60 @@ procedure Blake3_Compress_Avx2(AState, AMsg, ACV, ACounterFlags: Pointer);
   {$I ..\Include\Simd\Blake3\Blake3CompressAvx2.inc}
 end;
 
+procedure Blake3_Hash4_Sse2(AInput, AKey, AOut: Pointer;
+  ANumChunks: Int32; ACounter: UInt64; AFlags: UInt32);
+  {$I ..\Include\Simd\Common\SimdProc6Begin.inc}
+  {$I ..\Include\Simd\Blake3\Blake3Hash4Sse2.inc}
+end;
+
+procedure Blake3_Hash8_Avx2(AInput, AKey, AOut: Pointer;
+  ANumChunks: Int32; ACounter: UInt64; AFlags: UInt32);
+  {$I ..\Include\Simd\Common\SimdProc6Begin.inc}
+  {$I ..\Include\Simd\Blake3\Blake3Hash8Avx2.inc}
+end;
+
+// Cascade wrappers matching the official BLAKE3 dispatch pattern:
+// AVX2 hash_many: hash8 -> delegate remainder to SSE2 hash_many
+// SSE2 hash_many: hash4 -> delegate remainder to scalar hash_many
+
+procedure Blake3_HashMany_Sse2(AInput, AKey, AOut: Pointer;
+  ANumChunks: Int32; ACounter: UInt64; AFlags: UInt32);
+var
+  LPInput, LPOut: PByte;
+begin
+  LPInput := PByte(AInput);
+  LPOut := PByte(AOut);
+  while ANumChunks >= 4 do
+  begin
+    Blake3_Hash4_Sse2(LPInput, AKey, LPOut, 4, ACounter, AFlags);
+    System.Inc(LPInput, 4 * 1024);
+    System.Inc(LPOut, 4 * 32);
+    System.Inc(ACounter, 4);
+    System.Dec(ANumChunks, 4);
+  end;
+  if ANumChunks > 0 then
+    Blake3_HashMany_Scalar(LPInput, AKey, LPOut, ANumChunks, ACounter, AFlags);
+end;
+
+procedure Blake3_HashMany_Avx2(AInput, AKey, AOut: Pointer;
+  ANumChunks: Int32; ACounter: UInt64; AFlags: UInt32);
+var
+  LPInput, LPOut: PByte;
+begin
+  LPInput := PByte(AInput);
+  LPOut := PByte(AOut);
+  while ANumChunks >= 8 do
+  begin
+    Blake3_Hash8_Avx2(LPInput, AKey, LPOut, 8, ACounter, AFlags);
+    System.Inc(LPInput, 8 * 1024);
+    System.Inc(LPOut, 8 * 32);
+    System.Inc(ACounter, 8);
+    System.Dec(ANumChunks, 8);
+  end;
+  if ANumChunks > 0 then
+    Blake3_HashMany_Sse2(LPInput, AKey, LPOut, ANumChunks, ACounter, AFlags);
+end;
+
 {$ENDIF HASHLIB_X86_64}
 
 // =============================================================================
@@ -642,11 +696,13 @@ begin
     TSimdLevel.AVX2:
     begin
       Blake3_Compress := @Blake3_Compress_Avx2;
+      Blake3_HashMany := @Blake3_HashMany_Avx2;
       Blake3_ParallelDegree := 8;
     end;
     TSimdLevel.SSE2, TSimdLevel.SSSE3:
     begin
       Blake3_Compress := @Blake3_Compress_Sse2;
+      Blake3_HashMany := @Blake3_HashMany_Sse2;
       Blake3_ParallelDegree := 4;
     end;
 {$ENDIF}

--- a/HashLib/src/Crypto/HlpBlake3Dispatch.pas
+++ b/HashLib/src/Crypto/HlpBlake3Dispatch.pas
@@ -7,8 +7,20 @@ interface
 type
   TBlake3CompressProc = procedure(AState, AMsg, ACV, ACounterFlags: Pointer);
 
+  // Hash N complete chunks in parallel.
+  // AInput: pointer to N * 1024 bytes of contiguous input
+  // AKey: pointer to 8 x UInt32 key/IV
+  // AOut: pointer to N * 8 x UInt32 output chaining values
+  // ANumChunks: number of chunks to hash
+  // ACounter: starting chunk counter
+  // AFlags: base flags (chunk start/end handled internally)
+  TBlake3HashManyProc = procedure(AInput, AKey, AOut: Pointer;
+    ANumChunks: Int32; ACounter: UInt64; AFlags: UInt32);
+
 var
   Blake3_Compress: TBlake3CompressProc;
+  Blake3_HashMany: TBlake3HashManyProc;
+  Blake3_ParallelDegree: Int32;
 
 implementation
 
@@ -17,79 +29,584 @@ uses
   HlpSimd;
 
 const
-  Blake3Sigma: array [0 .. 6, 0 .. 15] of Int32 = (
-    (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15),
-    (2, 6, 3, 10, 7, 0, 4, 13, 1, 11, 12, 5, 9, 14, 15, 8),
-    (3, 4, 10, 12, 13, 2, 7, 14, 6, 5, 9, 0, 11, 15, 8, 1),
-    (10, 7, 12, 9, 14, 3, 13, 15, 4, 0, 11, 2, 5, 8, 1, 6),
-    (12, 13, 9, 11, 15, 10, 14, 8, 7, 2, 5, 3, 0, 1, 6, 4),
-    (9, 14, 11, 5, 8, 12, 15, 1, 13, 3, 0, 10, 2, 6, 4, 7),
-    (11, 15, 5, 0, 1, 9, 8, 6, 14, 10, 2, 12, 3, 4, 7, 13)
-  );
-
   Blake3IV: array [0 .. 3] of UInt32 = (
     UInt32($6A09E667), UInt32($BB67AE85),
     UInt32($3C6EF372), UInt32($A54FF53A)
   );
 
+  FlagChunkStart = UInt32(1 shl 0);
+  FlagChunkEnd = UInt32(1 shl 1);
+
 // =============================================================================
-// Scalar fallback implementation
+// Scalar fallback implementation (fully unrolled, 7 rounds, inlined G)
 // =============================================================================
 
 procedure Blake3_Compress_Scalar(AState, AMsg, ACV, ACounterFlags: Pointer);
 var
-  LV: array [0 .. 15] of UInt32;
-  LPMsg, LPCV, LPCounterFlags: PCardinal;
-  LRound: Int32;
-
-  procedure G(AA, AB, AC, AD, AMsgIdx0, AMsgIdx1: Int32);
-  begin
-    LV[AA] := LV[AA] + LV[AB] + LPMsg[AMsgIdx0];
-    LV[AD] := TBits.RotateRight32(LV[AD] xor LV[AA], 16);
-    LV[AC] := LV[AC] + LV[AD];
-    LV[AB] := TBits.RotateRight32(LV[AB] xor LV[AC], 12);
-    LV[AA] := LV[AA] + LV[AB] + LPMsg[AMsgIdx1];
-    LV[AD] := TBits.RotateRight32(LV[AD] xor LV[AA], 8);
-    LV[AC] := LV[AC] + LV[AD];
-    LV[AB] := TBits.RotateRight32(LV[AB] xor LV[AC], 7);
-  end;
-
-var
-  LPState: PCardinal;
-  I: Int32;
+  v0, v1, v2, v3, v4, v5, v6, v7: UInt32;
+  v8, v9, v10, v11, v12, v13, v14, v15: UInt32;
+  LPMsg, LPCV, LPCounterFlags, LPState: PCardinal;
 begin
   LPMsg := PCardinal(AMsg);
   LPCV := PCardinal(ACV);
   LPCounterFlags := PCardinal(ACounterFlags);
   LPState := PCardinal(AState);
 
-  for I := 0 to 7 do
-    LV[I] := LPCV[I];
-  LV[8] := Blake3IV[0];
-  LV[9] := Blake3IV[1];
-  LV[10] := Blake3IV[2];
-  LV[11] := Blake3IV[3];
-  LV[12] := LPCounterFlags[0];
-  LV[13] := LPCounterFlags[1];
-  LV[14] := LPCounterFlags[2];
-  LV[15] := LPCounterFlags[3];
+  // Initialize state from chaining value
+  v0 := LPCV[0];
+  v1 := LPCV[1];
+  v2 := LPCV[2];
+  v3 := LPCV[3];
+  v4 := LPCV[4];
+  v5 := LPCV[5];
+  v6 := LPCV[6];
+  v7 := LPCV[7];
+  // Initialize counter half from IV and counter/flags
+  v8 := Blake3IV[0];
+  v9 := Blake3IV[1];
+  v10 := Blake3IV[2];
+  v11 := Blake3IV[3];
+  v12 := LPCounterFlags[0];
+  v13 := LPCounterFlags[1];
+  v14 := LPCounterFlags[2];
+  v15 := LPCounterFlags[3];
 
-  for LRound := 0 to 6 do
+  // Round 0
+  v0 := v0 + v4 + LPMsg[0];
+  v12 := TBits.RotateRight32(v12 xor v0, 16);
+  v8 := v8 + v12;
+  v4 := TBits.RotateRight32(v4 xor v8, 12);
+  v0 := v0 + v4 + LPMsg[1];
+  v12 := TBits.RotateRight32(v12 xor v0, 8);
+  v8 := v8 + v12;
+  v4 := TBits.RotateRight32(v4 xor v8, 7);
+  v1 := v1 + v5 + LPMsg[2];
+  v13 := TBits.RotateRight32(v13 xor v1, 16);
+  v9 := v9 + v13;
+  v5 := TBits.RotateRight32(v5 xor v9, 12);
+  v1 := v1 + v5 + LPMsg[3];
+  v13 := TBits.RotateRight32(v13 xor v1, 8);
+  v9 := v9 + v13;
+  v5 := TBits.RotateRight32(v5 xor v9, 7);
+  v2 := v2 + v6 + LPMsg[4];
+  v14 := TBits.RotateRight32(v14 xor v2, 16);
+  v10 := v10 + v14;
+  v6 := TBits.RotateRight32(v6 xor v10, 12);
+  v2 := v2 + v6 + LPMsg[5];
+  v14 := TBits.RotateRight32(v14 xor v2, 8);
+  v10 := v10 + v14;
+  v6 := TBits.RotateRight32(v6 xor v10, 7);
+  v3 := v3 + v7 + LPMsg[6];
+  v15 := TBits.RotateRight32(v15 xor v3, 16);
+  v11 := v11 + v15;
+  v7 := TBits.RotateRight32(v7 xor v11, 12);
+  v3 := v3 + v7 + LPMsg[7];
+  v15 := TBits.RotateRight32(v15 xor v3, 8);
+  v11 := v11 + v15;
+  v7 := TBits.RotateRight32(v7 xor v11, 7);
+  v0 := v0 + v5 + LPMsg[8];
+  v15 := TBits.RotateRight32(v15 xor v0, 16);
+  v10 := v10 + v15;
+  v5 := TBits.RotateRight32(v5 xor v10, 12);
+  v0 := v0 + v5 + LPMsg[9];
+  v15 := TBits.RotateRight32(v15 xor v0, 8);
+  v10 := v10 + v15;
+  v5 := TBits.RotateRight32(v5 xor v10, 7);
+  v1 := v1 + v6 + LPMsg[10];
+  v12 := TBits.RotateRight32(v12 xor v1, 16);
+  v11 := v11 + v12;
+  v6 := TBits.RotateRight32(v6 xor v11, 12);
+  v1 := v1 + v6 + LPMsg[11];
+  v12 := TBits.RotateRight32(v12 xor v1, 8);
+  v11 := v11 + v12;
+  v6 := TBits.RotateRight32(v6 xor v11, 7);
+  v2 := v2 + v7 + LPMsg[12];
+  v13 := TBits.RotateRight32(v13 xor v2, 16);
+  v8 := v8 + v13;
+  v7 := TBits.RotateRight32(v7 xor v8, 12);
+  v2 := v2 + v7 + LPMsg[13];
+  v13 := TBits.RotateRight32(v13 xor v2, 8);
+  v8 := v8 + v13;
+  v7 := TBits.RotateRight32(v7 xor v8, 7);
+  v3 := v3 + v4 + LPMsg[14];
+  v14 := TBits.RotateRight32(v14 xor v3, 16);
+  v9 := v9 + v14;
+  v4 := TBits.RotateRight32(v4 xor v9, 12);
+  v3 := v3 + v4 + LPMsg[15];
+  v14 := TBits.RotateRight32(v14 xor v3, 8);
+  v9 := v9 + v14;
+  v4 := TBits.RotateRight32(v4 xor v9, 7);
+
+  // Round 1
+  v0 := v0 + v4 + LPMsg[2];
+  v12 := TBits.RotateRight32(v12 xor v0, 16);
+  v8 := v8 + v12;
+  v4 := TBits.RotateRight32(v4 xor v8, 12);
+  v0 := v0 + v4 + LPMsg[6];
+  v12 := TBits.RotateRight32(v12 xor v0, 8);
+  v8 := v8 + v12;
+  v4 := TBits.RotateRight32(v4 xor v8, 7);
+  v1 := v1 + v5 + LPMsg[3];
+  v13 := TBits.RotateRight32(v13 xor v1, 16);
+  v9 := v9 + v13;
+  v5 := TBits.RotateRight32(v5 xor v9, 12);
+  v1 := v1 + v5 + LPMsg[10];
+  v13 := TBits.RotateRight32(v13 xor v1, 8);
+  v9 := v9 + v13;
+  v5 := TBits.RotateRight32(v5 xor v9, 7);
+  v2 := v2 + v6 + LPMsg[7];
+  v14 := TBits.RotateRight32(v14 xor v2, 16);
+  v10 := v10 + v14;
+  v6 := TBits.RotateRight32(v6 xor v10, 12);
+  v2 := v2 + v6 + LPMsg[0];
+  v14 := TBits.RotateRight32(v14 xor v2, 8);
+  v10 := v10 + v14;
+  v6 := TBits.RotateRight32(v6 xor v10, 7);
+  v3 := v3 + v7 + LPMsg[4];
+  v15 := TBits.RotateRight32(v15 xor v3, 16);
+  v11 := v11 + v15;
+  v7 := TBits.RotateRight32(v7 xor v11, 12);
+  v3 := v3 + v7 + LPMsg[13];
+  v15 := TBits.RotateRight32(v15 xor v3, 8);
+  v11 := v11 + v15;
+  v7 := TBits.RotateRight32(v7 xor v11, 7);
+  v0 := v0 + v5 + LPMsg[1];
+  v15 := TBits.RotateRight32(v15 xor v0, 16);
+  v10 := v10 + v15;
+  v5 := TBits.RotateRight32(v5 xor v10, 12);
+  v0 := v0 + v5 + LPMsg[11];
+  v15 := TBits.RotateRight32(v15 xor v0, 8);
+  v10 := v10 + v15;
+  v5 := TBits.RotateRight32(v5 xor v10, 7);
+  v1 := v1 + v6 + LPMsg[12];
+  v12 := TBits.RotateRight32(v12 xor v1, 16);
+  v11 := v11 + v12;
+  v6 := TBits.RotateRight32(v6 xor v11, 12);
+  v1 := v1 + v6 + LPMsg[5];
+  v12 := TBits.RotateRight32(v12 xor v1, 8);
+  v11 := v11 + v12;
+  v6 := TBits.RotateRight32(v6 xor v11, 7);
+  v2 := v2 + v7 + LPMsg[9];
+  v13 := TBits.RotateRight32(v13 xor v2, 16);
+  v8 := v8 + v13;
+  v7 := TBits.RotateRight32(v7 xor v8, 12);
+  v2 := v2 + v7 + LPMsg[14];
+  v13 := TBits.RotateRight32(v13 xor v2, 8);
+  v8 := v8 + v13;
+  v7 := TBits.RotateRight32(v7 xor v8, 7);
+  v3 := v3 + v4 + LPMsg[15];
+  v14 := TBits.RotateRight32(v14 xor v3, 16);
+  v9 := v9 + v14;
+  v4 := TBits.RotateRight32(v4 xor v9, 12);
+  v3 := v3 + v4 + LPMsg[8];
+  v14 := TBits.RotateRight32(v14 xor v3, 8);
+  v9 := v9 + v14;
+  v4 := TBits.RotateRight32(v4 xor v9, 7);
+
+  // Round 2
+  v0 := v0 + v4 + LPMsg[3];
+  v12 := TBits.RotateRight32(v12 xor v0, 16);
+  v8 := v8 + v12;
+  v4 := TBits.RotateRight32(v4 xor v8, 12);
+  v0 := v0 + v4 + LPMsg[4];
+  v12 := TBits.RotateRight32(v12 xor v0, 8);
+  v8 := v8 + v12;
+  v4 := TBits.RotateRight32(v4 xor v8, 7);
+  v1 := v1 + v5 + LPMsg[10];
+  v13 := TBits.RotateRight32(v13 xor v1, 16);
+  v9 := v9 + v13;
+  v5 := TBits.RotateRight32(v5 xor v9, 12);
+  v1 := v1 + v5 + LPMsg[12];
+  v13 := TBits.RotateRight32(v13 xor v1, 8);
+  v9 := v9 + v13;
+  v5 := TBits.RotateRight32(v5 xor v9, 7);
+  v2 := v2 + v6 + LPMsg[13];
+  v14 := TBits.RotateRight32(v14 xor v2, 16);
+  v10 := v10 + v14;
+  v6 := TBits.RotateRight32(v6 xor v10, 12);
+  v2 := v2 + v6 + LPMsg[2];
+  v14 := TBits.RotateRight32(v14 xor v2, 8);
+  v10 := v10 + v14;
+  v6 := TBits.RotateRight32(v6 xor v10, 7);
+  v3 := v3 + v7 + LPMsg[7];
+  v15 := TBits.RotateRight32(v15 xor v3, 16);
+  v11 := v11 + v15;
+  v7 := TBits.RotateRight32(v7 xor v11, 12);
+  v3 := v3 + v7 + LPMsg[14];
+  v15 := TBits.RotateRight32(v15 xor v3, 8);
+  v11 := v11 + v15;
+  v7 := TBits.RotateRight32(v7 xor v11, 7);
+  v0 := v0 + v5 + LPMsg[6];
+  v15 := TBits.RotateRight32(v15 xor v0, 16);
+  v10 := v10 + v15;
+  v5 := TBits.RotateRight32(v5 xor v10, 12);
+  v0 := v0 + v5 + LPMsg[5];
+  v15 := TBits.RotateRight32(v15 xor v0, 8);
+  v10 := v10 + v15;
+  v5 := TBits.RotateRight32(v5 xor v10, 7);
+  v1 := v1 + v6 + LPMsg[9];
+  v12 := TBits.RotateRight32(v12 xor v1, 16);
+  v11 := v11 + v12;
+  v6 := TBits.RotateRight32(v6 xor v11, 12);
+  v1 := v1 + v6 + LPMsg[0];
+  v12 := TBits.RotateRight32(v12 xor v1, 8);
+  v11 := v11 + v12;
+  v6 := TBits.RotateRight32(v6 xor v11, 7);
+  v2 := v2 + v7 + LPMsg[11];
+  v13 := TBits.RotateRight32(v13 xor v2, 16);
+  v8 := v8 + v13;
+  v7 := TBits.RotateRight32(v7 xor v8, 12);
+  v2 := v2 + v7 + LPMsg[15];
+  v13 := TBits.RotateRight32(v13 xor v2, 8);
+  v8 := v8 + v13;
+  v7 := TBits.RotateRight32(v7 xor v8, 7);
+  v3 := v3 + v4 + LPMsg[8];
+  v14 := TBits.RotateRight32(v14 xor v3, 16);
+  v9 := v9 + v14;
+  v4 := TBits.RotateRight32(v4 xor v9, 12);
+  v3 := v3 + v4 + LPMsg[1];
+  v14 := TBits.RotateRight32(v14 xor v3, 8);
+  v9 := v9 + v14;
+  v4 := TBits.RotateRight32(v4 xor v9, 7);
+
+  // Round 3
+  v0 := v0 + v4 + LPMsg[10];
+  v12 := TBits.RotateRight32(v12 xor v0, 16);
+  v8 := v8 + v12;
+  v4 := TBits.RotateRight32(v4 xor v8, 12);
+  v0 := v0 + v4 + LPMsg[7];
+  v12 := TBits.RotateRight32(v12 xor v0, 8);
+  v8 := v8 + v12;
+  v4 := TBits.RotateRight32(v4 xor v8, 7);
+  v1 := v1 + v5 + LPMsg[12];
+  v13 := TBits.RotateRight32(v13 xor v1, 16);
+  v9 := v9 + v13;
+  v5 := TBits.RotateRight32(v5 xor v9, 12);
+  v1 := v1 + v5 + LPMsg[9];
+  v13 := TBits.RotateRight32(v13 xor v1, 8);
+  v9 := v9 + v13;
+  v5 := TBits.RotateRight32(v5 xor v9, 7);
+  v2 := v2 + v6 + LPMsg[14];
+  v14 := TBits.RotateRight32(v14 xor v2, 16);
+  v10 := v10 + v14;
+  v6 := TBits.RotateRight32(v6 xor v10, 12);
+  v2 := v2 + v6 + LPMsg[3];
+  v14 := TBits.RotateRight32(v14 xor v2, 8);
+  v10 := v10 + v14;
+  v6 := TBits.RotateRight32(v6 xor v10, 7);
+  v3 := v3 + v7 + LPMsg[13];
+  v15 := TBits.RotateRight32(v15 xor v3, 16);
+  v11 := v11 + v15;
+  v7 := TBits.RotateRight32(v7 xor v11, 12);
+  v3 := v3 + v7 + LPMsg[15];
+  v15 := TBits.RotateRight32(v15 xor v3, 8);
+  v11 := v11 + v15;
+  v7 := TBits.RotateRight32(v7 xor v11, 7);
+  v0 := v0 + v5 + LPMsg[4];
+  v15 := TBits.RotateRight32(v15 xor v0, 16);
+  v10 := v10 + v15;
+  v5 := TBits.RotateRight32(v5 xor v10, 12);
+  v0 := v0 + v5 + LPMsg[0];
+  v15 := TBits.RotateRight32(v15 xor v0, 8);
+  v10 := v10 + v15;
+  v5 := TBits.RotateRight32(v5 xor v10, 7);
+  v1 := v1 + v6 + LPMsg[11];
+  v12 := TBits.RotateRight32(v12 xor v1, 16);
+  v11 := v11 + v12;
+  v6 := TBits.RotateRight32(v6 xor v11, 12);
+  v1 := v1 + v6 + LPMsg[2];
+  v12 := TBits.RotateRight32(v12 xor v1, 8);
+  v11 := v11 + v12;
+  v6 := TBits.RotateRight32(v6 xor v11, 7);
+  v2 := v2 + v7 + LPMsg[5];
+  v13 := TBits.RotateRight32(v13 xor v2, 16);
+  v8 := v8 + v13;
+  v7 := TBits.RotateRight32(v7 xor v8, 12);
+  v2 := v2 + v7 + LPMsg[8];
+  v13 := TBits.RotateRight32(v13 xor v2, 8);
+  v8 := v8 + v13;
+  v7 := TBits.RotateRight32(v7 xor v8, 7);
+  v3 := v3 + v4 + LPMsg[1];
+  v14 := TBits.RotateRight32(v14 xor v3, 16);
+  v9 := v9 + v14;
+  v4 := TBits.RotateRight32(v4 xor v9, 12);
+  v3 := v3 + v4 + LPMsg[6];
+  v14 := TBits.RotateRight32(v14 xor v3, 8);
+  v9 := v9 + v14;
+  v4 := TBits.RotateRight32(v4 xor v9, 7);
+
+  // Round 4
+  v0 := v0 + v4 + LPMsg[12];
+  v12 := TBits.RotateRight32(v12 xor v0, 16);
+  v8 := v8 + v12;
+  v4 := TBits.RotateRight32(v4 xor v8, 12);
+  v0 := v0 + v4 + LPMsg[13];
+  v12 := TBits.RotateRight32(v12 xor v0, 8);
+  v8 := v8 + v12;
+  v4 := TBits.RotateRight32(v4 xor v8, 7);
+  v1 := v1 + v5 + LPMsg[9];
+  v13 := TBits.RotateRight32(v13 xor v1, 16);
+  v9 := v9 + v13;
+  v5 := TBits.RotateRight32(v5 xor v9, 12);
+  v1 := v1 + v5 + LPMsg[11];
+  v13 := TBits.RotateRight32(v13 xor v1, 8);
+  v9 := v9 + v13;
+  v5 := TBits.RotateRight32(v5 xor v9, 7);
+  v2 := v2 + v6 + LPMsg[15];
+  v14 := TBits.RotateRight32(v14 xor v2, 16);
+  v10 := v10 + v14;
+  v6 := TBits.RotateRight32(v6 xor v10, 12);
+  v2 := v2 + v6 + LPMsg[10];
+  v14 := TBits.RotateRight32(v14 xor v2, 8);
+  v10 := v10 + v14;
+  v6 := TBits.RotateRight32(v6 xor v10, 7);
+  v3 := v3 + v7 + LPMsg[14];
+  v15 := TBits.RotateRight32(v15 xor v3, 16);
+  v11 := v11 + v15;
+  v7 := TBits.RotateRight32(v7 xor v11, 12);
+  v3 := v3 + v7 + LPMsg[8];
+  v15 := TBits.RotateRight32(v15 xor v3, 8);
+  v11 := v11 + v15;
+  v7 := TBits.RotateRight32(v7 xor v11, 7);
+  v0 := v0 + v5 + LPMsg[7];
+  v15 := TBits.RotateRight32(v15 xor v0, 16);
+  v10 := v10 + v15;
+  v5 := TBits.RotateRight32(v5 xor v10, 12);
+  v0 := v0 + v5 + LPMsg[2];
+  v15 := TBits.RotateRight32(v15 xor v0, 8);
+  v10 := v10 + v15;
+  v5 := TBits.RotateRight32(v5 xor v10, 7);
+  v1 := v1 + v6 + LPMsg[5];
+  v12 := TBits.RotateRight32(v12 xor v1, 16);
+  v11 := v11 + v12;
+  v6 := TBits.RotateRight32(v6 xor v11, 12);
+  v1 := v1 + v6 + LPMsg[3];
+  v12 := TBits.RotateRight32(v12 xor v1, 8);
+  v11 := v11 + v12;
+  v6 := TBits.RotateRight32(v6 xor v11, 7);
+  v2 := v2 + v7 + LPMsg[0];
+  v13 := TBits.RotateRight32(v13 xor v2, 16);
+  v8 := v8 + v13;
+  v7 := TBits.RotateRight32(v7 xor v8, 12);
+  v2 := v2 + v7 + LPMsg[1];
+  v13 := TBits.RotateRight32(v13 xor v2, 8);
+  v8 := v8 + v13;
+  v7 := TBits.RotateRight32(v7 xor v8, 7);
+  v3 := v3 + v4 + LPMsg[6];
+  v14 := TBits.RotateRight32(v14 xor v3, 16);
+  v9 := v9 + v14;
+  v4 := TBits.RotateRight32(v4 xor v9, 12);
+  v3 := v3 + v4 + LPMsg[4];
+  v14 := TBits.RotateRight32(v14 xor v3, 8);
+  v9 := v9 + v14;
+  v4 := TBits.RotateRight32(v4 xor v9, 7);
+
+  // Round 5
+  v0 := v0 + v4 + LPMsg[9];
+  v12 := TBits.RotateRight32(v12 xor v0, 16);
+  v8 := v8 + v12;
+  v4 := TBits.RotateRight32(v4 xor v8, 12);
+  v0 := v0 + v4 + LPMsg[14];
+  v12 := TBits.RotateRight32(v12 xor v0, 8);
+  v8 := v8 + v12;
+  v4 := TBits.RotateRight32(v4 xor v8, 7);
+  v1 := v1 + v5 + LPMsg[11];
+  v13 := TBits.RotateRight32(v13 xor v1, 16);
+  v9 := v9 + v13;
+  v5 := TBits.RotateRight32(v5 xor v9, 12);
+  v1 := v1 + v5 + LPMsg[5];
+  v13 := TBits.RotateRight32(v13 xor v1, 8);
+  v9 := v9 + v13;
+  v5 := TBits.RotateRight32(v5 xor v9, 7);
+  v2 := v2 + v6 + LPMsg[8];
+  v14 := TBits.RotateRight32(v14 xor v2, 16);
+  v10 := v10 + v14;
+  v6 := TBits.RotateRight32(v6 xor v10, 12);
+  v2 := v2 + v6 + LPMsg[12];
+  v14 := TBits.RotateRight32(v14 xor v2, 8);
+  v10 := v10 + v14;
+  v6 := TBits.RotateRight32(v6 xor v10, 7);
+  v3 := v3 + v7 + LPMsg[15];
+  v15 := TBits.RotateRight32(v15 xor v3, 16);
+  v11 := v11 + v15;
+  v7 := TBits.RotateRight32(v7 xor v11, 12);
+  v3 := v3 + v7 + LPMsg[1];
+  v15 := TBits.RotateRight32(v15 xor v3, 8);
+  v11 := v11 + v15;
+  v7 := TBits.RotateRight32(v7 xor v11, 7);
+  v0 := v0 + v5 + LPMsg[13];
+  v15 := TBits.RotateRight32(v15 xor v0, 16);
+  v10 := v10 + v15;
+  v5 := TBits.RotateRight32(v5 xor v10, 12);
+  v0 := v0 + v5 + LPMsg[3];
+  v15 := TBits.RotateRight32(v15 xor v0, 8);
+  v10 := v10 + v15;
+  v5 := TBits.RotateRight32(v5 xor v10, 7);
+  v1 := v1 + v6 + LPMsg[0];
+  v12 := TBits.RotateRight32(v12 xor v1, 16);
+  v11 := v11 + v12;
+  v6 := TBits.RotateRight32(v6 xor v11, 12);
+  v1 := v1 + v6 + LPMsg[10];
+  v12 := TBits.RotateRight32(v12 xor v1, 8);
+  v11 := v11 + v12;
+  v6 := TBits.RotateRight32(v6 xor v11, 7);
+  v2 := v2 + v7 + LPMsg[2];
+  v13 := TBits.RotateRight32(v13 xor v2, 16);
+  v8 := v8 + v13;
+  v7 := TBits.RotateRight32(v7 xor v8, 12);
+  v2 := v2 + v7 + LPMsg[6];
+  v13 := TBits.RotateRight32(v13 xor v2, 8);
+  v8 := v8 + v13;
+  v7 := TBits.RotateRight32(v7 xor v8, 7);
+  v3 := v3 + v4 + LPMsg[4];
+  v14 := TBits.RotateRight32(v14 xor v3, 16);
+  v9 := v9 + v14;
+  v4 := TBits.RotateRight32(v4 xor v9, 12);
+  v3 := v3 + v4 + LPMsg[7];
+  v14 := TBits.RotateRight32(v14 xor v3, 8);
+  v9 := v9 + v14;
+  v4 := TBits.RotateRight32(v4 xor v9, 7);
+
+  // Round 6
+  v0 := v0 + v4 + LPMsg[11];
+  v12 := TBits.RotateRight32(v12 xor v0, 16);
+  v8 := v8 + v12;
+  v4 := TBits.RotateRight32(v4 xor v8, 12);
+  v0 := v0 + v4 + LPMsg[15];
+  v12 := TBits.RotateRight32(v12 xor v0, 8);
+  v8 := v8 + v12;
+  v4 := TBits.RotateRight32(v4 xor v8, 7);
+  v1 := v1 + v5 + LPMsg[5];
+  v13 := TBits.RotateRight32(v13 xor v1, 16);
+  v9 := v9 + v13;
+  v5 := TBits.RotateRight32(v5 xor v9, 12);
+  v1 := v1 + v5 + LPMsg[0];
+  v13 := TBits.RotateRight32(v13 xor v1, 8);
+  v9 := v9 + v13;
+  v5 := TBits.RotateRight32(v5 xor v9, 7);
+  v2 := v2 + v6 + LPMsg[1];
+  v14 := TBits.RotateRight32(v14 xor v2, 16);
+  v10 := v10 + v14;
+  v6 := TBits.RotateRight32(v6 xor v10, 12);
+  v2 := v2 + v6 + LPMsg[9];
+  v14 := TBits.RotateRight32(v14 xor v2, 8);
+  v10 := v10 + v14;
+  v6 := TBits.RotateRight32(v6 xor v10, 7);
+  v3 := v3 + v7 + LPMsg[8];
+  v15 := TBits.RotateRight32(v15 xor v3, 16);
+  v11 := v11 + v15;
+  v7 := TBits.RotateRight32(v7 xor v11, 12);
+  v3 := v3 + v7 + LPMsg[6];
+  v15 := TBits.RotateRight32(v15 xor v3, 8);
+  v11 := v11 + v15;
+  v7 := TBits.RotateRight32(v7 xor v11, 7);
+  v0 := v0 + v5 + LPMsg[14];
+  v15 := TBits.RotateRight32(v15 xor v0, 16);
+  v10 := v10 + v15;
+  v5 := TBits.RotateRight32(v5 xor v10, 12);
+  v0 := v0 + v5 + LPMsg[10];
+  v15 := TBits.RotateRight32(v15 xor v0, 8);
+  v10 := v10 + v15;
+  v5 := TBits.RotateRight32(v5 xor v10, 7);
+  v1 := v1 + v6 + LPMsg[2];
+  v12 := TBits.RotateRight32(v12 xor v1, 16);
+  v11 := v11 + v12;
+  v6 := TBits.RotateRight32(v6 xor v11, 12);
+  v1 := v1 + v6 + LPMsg[12];
+  v12 := TBits.RotateRight32(v12 xor v1, 8);
+  v11 := v11 + v12;
+  v6 := TBits.RotateRight32(v6 xor v11, 7);
+  v2 := v2 + v7 + LPMsg[3];
+  v13 := TBits.RotateRight32(v13 xor v2, 16);
+  v8 := v8 + v13;
+  v7 := TBits.RotateRight32(v7 xor v8, 12);
+  v2 := v2 + v7 + LPMsg[4];
+  v13 := TBits.RotateRight32(v13 xor v2, 8);
+  v8 := v8 + v13;
+  v7 := TBits.RotateRight32(v7 xor v8, 7);
+  v3 := v3 + v4 + LPMsg[7];
+  v14 := TBits.RotateRight32(v14 xor v3, 16);
+  v9 := v9 + v14;
+  v4 := TBits.RotateRight32(v4 xor v9, 12);
+  v3 := v3 + v4 + LPMsg[13];
+  v14 := TBits.RotateRight32(v14 xor v3, 8);
+  v9 := v9 + v14;
+  v4 := TBits.RotateRight32(v4 xor v9, 7);
+
+  // Finalization: XOR top and bottom halves
+  LPState[0] := v0 xor v8;
+  LPState[1] := v1 xor v9;
+  LPState[2] := v2 xor v10;
+  LPState[3] := v3 xor v11;
+  LPState[4] := v4 xor v12;
+  LPState[5] := v5 xor v13;
+  LPState[6] := v6 xor v14;
+  LPState[7] := v7 xor v15;
+  LPState[8] := v8 xor LPCV[0];
+  LPState[9] := v9 xor LPCV[1];
+  LPState[10] := v10 xor LPCV[2];
+  LPState[11] := v11 xor LPCV[3];
+  LPState[12] := v12 xor LPCV[4];
+  LPState[13] := v13 xor LPCV[5];
+  LPState[14] := v14 xor LPCV[6];
+  LPState[15] := v15 xor LPCV[7];
+end;
+
+// =============================================================================
+// Scalar HashMany fallback (sequential, no parallelism)
+// =============================================================================
+
+procedure Blake3_HashMany_Scalar(AInput, AKey, AOut: Pointer;
+  ANumChunks: Int32; ACounter: UInt64; AFlags: UInt32);
+var
+  LChunk, LBlock: Int32;
+  LCV: array [0 .. 7] of UInt32;
+  LBlockWords: array [0 .. 15] of UInt32;
+  LState: array [0 .. 15] of UInt32;
+  LCounterFlags: array [0 .. 3] of UInt32;
+  LBlockFlags: UInt32;
+  LPInput, LPOut: PByte;
+begin
+  LPInput := PByte(AInput);
+  LPOut := PByte(AOut);
+
+  for LChunk := 0 to ANumChunks - 1 do
   begin
-    G(0, 4, 8, 12, Blake3Sigma[LRound, 0], Blake3Sigma[LRound, 1]);
-    G(1, 5, 9, 13, Blake3Sigma[LRound, 2], Blake3Sigma[LRound, 3]);
-    G(2, 6, 10, 14, Blake3Sigma[LRound, 4], Blake3Sigma[LRound, 5]);
-    G(3, 7, 11, 15, Blake3Sigma[LRound, 6], Blake3Sigma[LRound, 7]);
-    G(0, 5, 10, 15, Blake3Sigma[LRound, 8], Blake3Sigma[LRound, 9]);
-    G(1, 6, 11, 12, Blake3Sigma[LRound, 10], Blake3Sigma[LRound, 11]);
-    G(2, 7, 8, 13, Blake3Sigma[LRound, 12], Blake3Sigma[LRound, 13]);
-    G(3, 4, 9, 14, Blake3Sigma[LRound, 14], Blake3Sigma[LRound, 15]);
-  end;
+    // Initialize CV from key/IV
+    System.Move(AKey^, LCV[0], 8 * System.SizeOf(UInt32));
 
-  for I := 0 to 7 do
-    LPState[I] := LV[I] xor LV[I + 8];
-  for I := 0 to 7 do
-    LPState[I + 8] := LV[I + 8] xor LPCV[I];
+    // Process 16 blocks per chunk
+    for LBlock := 0 to 15 do
+    begin
+      // Convert block bytes to words (little-endian, which is native on x86)
+      System.Move(LPInput^, LBlockWords[0], 64);
+
+      // Set flags for this block
+      LBlockFlags := AFlags;
+      if LBlock = 0 then
+        LBlockFlags := LBlockFlags or FlagChunkStart;
+      if LBlock = 15 then
+        LBlockFlags := LBlockFlags or FlagChunkEnd;
+
+      LCounterFlags[0] := UInt32(ACounter);
+      LCounterFlags[1] := UInt32(ACounter shr 32);
+      LCounterFlags[2] := 64; // BlockLen = 64
+      LCounterFlags[3] := LBlockFlags;
+
+      Blake3_Compress(@LState[0], @LBlockWords[0], @LCV[0], @LCounterFlags[0]);
+
+      // Extract chaining value (first 8 words of output)
+      if LBlock < 15 then
+        System.Move(LState[0], LCV[0], 8 * System.SizeOf(UInt32));
+
+      System.Inc(LPInput, 64);
+    end;
+
+    // Write final chaining value for this chunk
+    System.Move(LState[0], LPOut^, 8 * System.SizeOf(UInt32));
+    System.Inc(LPOut, 8 * System.SizeOf(UInt32));
+    System.Inc(ACounter);
+  end;
 end;
 
 // =============================================================================
@@ -116,15 +633,21 @@ end;
 
 procedure InitDispatch();
 begin
+  // HashMany always has a scalar fallback available
+  Blake3_HashMany := @Blake3_HashMany_Scalar;
+  Blake3_ParallelDegree := 1;
+
   case TSimd.GetActiveLevel() of
 {$IFDEF HASHLIB_X86_64}
     TSimdLevel.AVX2:
     begin
       Blake3_Compress := @Blake3_Compress_Avx2;
+      Blake3_ParallelDegree := 8;
     end;
     TSimdLevel.SSE2, TSimdLevel.SSSE3:
     begin
       Blake3_Compress := @Blake3_Compress_Sse2;
+      Blake3_ParallelDegree := 4;
     end;
 {$ENDIF}
     TSimdLevel.Scalar:

--- a/HashLib/src/Include/Simd/Blake3/Blake3Hash4Sse2.inc
+++ b/HashLib/src/Include/Simd/Blake3/Blake3Hash4Sse2.inc
@@ -1,0 +1,1852 @@
+// SSE2 implementation of BLAKE3 hash4: processes 4 independent chunks simultaneously.
+// Reference: BLAKE3-team/BLAKE3 official SSE2 implementation (blake3_sse2.c / blake3_hash_many).
+// Each XMM register holds the same 32-bit word from 4 different chunks (inter-chunk SIMD).
+// 7 rounds per block fully unrolled; 16-block loop with branch for chunk start/end flags.
+//
+// After SimdProc6Begin.inc:
+//   rcx = AInput, rdx = AKey, r8 = AOut,
+//   r9 = ANumChunks, r10 = ACounter, r11 = AFlags
+//
+// Register map: xmm0-xmm7 = state v0-v7, xmm8-xmm11 = state v8-v11,
+//   xmm12-xmm13 = temp, v12-v15 spilled to stack.
+// GPR: rcx = input pointer, rbx = block counter (0..15), rbp = block byte offset.
+// Message transpose: 4x4 via punpckldq/punpckhdq + punpcklqdq/punpckhqdq (pure SSE2).
+// Rotations: rot16 via pshuflw+pshufhw; rot12/8/7 via pslld/psrld/por.
+
+  push rbx
+  push rbp
+
+{$IFDEF MSWINDOWS}
+  sub rsp, 712
+  movdqa oword [rsp + 576], xmm6
+  movdqa oword [rsp + 592], xmm7
+  movdqa oword [rsp + 608], xmm8
+  movdqa oword [rsp + 624], xmm9
+  movdqa oword [rsp + 640], xmm10
+  movdqa oword [rsp + 656], xmm11
+  movdqa oword [rsp + 672], xmm12
+  movdqa oword [rsp + 688], xmm13
+{$ELSE}
+  sub rsp, 584
+{$ENDIF}
+
+  mov qword ptr [rsp + 560], r8
+  mov dword ptr [rsp + 568], r11d
+
+  // Broadcast key words to CV registers
+  movd xmm0, dword ptr [rdx + 0]
+  pshufd xmm0, xmm0, 0
+  movd xmm1, dword ptr [rdx + 4]
+  pshufd xmm1, xmm1, 0
+  movd xmm2, dword ptr [rdx + 8]
+  pshufd xmm2, xmm2, 0
+  movd xmm3, dword ptr [rdx + 12]
+  pshufd xmm3, xmm3, 0
+  movd xmm4, dword ptr [rdx + 16]
+  pshufd xmm4, xmm4, 0
+  movd xmm5, dword ptr [rdx + 20]
+  pshufd xmm5, xmm5, 0
+  movd xmm6, dword ptr [rdx + 24]
+  pshufd xmm6, xmm6, 0
+  movd xmm7, dword ptr [rdx + 28]
+  pshufd xmm7, xmm7, 0
+
+  // Save initial CV to stack
+  movdqa oword [rsp + 320], xmm0
+  movdqa oword [rsp + 336], xmm1
+  movdqa oword [rsp + 352], xmm2
+  movdqa oword [rsp + 368], xmm3
+  movdqa oword [rsp + 384], xmm4
+  movdqa oword [rsp + 400], xmm5
+  movdqa oword [rsp + 416], xmm6
+  movdqa oword [rsp + 432], xmm7
+
+  // Build counter vectors (r10 = ACounter, 64-bit)
+  mov rax, r10
+  mov dword ptr [rsp + 448], eax
+  shr rax, 32
+  mov dword ptr [rsp + 464], eax
+  lea rax, [r10 + 1]
+  mov dword ptr [rsp + 452], eax
+  shr rax, 32
+  mov dword ptr [rsp + 468], eax
+  lea rax, [r10 + 2]
+  mov dword ptr [rsp + 456], eax
+  shr rax, 32
+  mov dword ptr [rsp + 472], eax
+  lea rax, [r10 + 3]
+  mov dword ptr [rsp + 460], eax
+  shr rax, 32
+  mov dword ptr [rsp + 476], eax
+
+  // Pre-compute IV broadcast vectors
+  mov eax, $6A09E667
+  movd xmm12, eax
+  pshufd xmm12, xmm12, 0
+  movdqa oword [rsp + 480], xmm12
+  mov eax, $BB67AE85
+  movd xmm12, eax
+  pshufd xmm12, xmm12, 0
+  movdqa oword [rsp + 496], xmm12
+  mov eax, $3C6EF372
+  movd xmm12, eax
+  pshufd xmm12, xmm12, 0
+  movdqa oword [rsp + 512], xmm12
+  mov eax, $A54FF53A
+  movd xmm12, eax
+  pshufd xmm12, xmm12, 0
+  movdqa oword [rsp + 528], xmm12
+
+  mov eax, 64
+  movd xmm12, eax
+  pshufd xmm12, xmm12, 0
+  movdqa oword [rsp + 544], xmm12
+
+  xor ebx, ebx
+  xor ebp, ebp
+
+@block_loop:
+
+  // Transpose message for current block from 4 chunks
+  // Words 0..3
+  movdqu xmm0, oword [rcx + rbp + 0]
+  movdqu xmm1, oword [rcx + rbp + 1024]
+  movdqu xmm2, oword [rcx + rbp + 2048]
+  movdqu xmm3, oword [rcx + rbp + 3072]
+  movdqa xmm4, xmm0
+  punpckldq xmm0, xmm1
+  punpckhdq xmm4, xmm1
+  movdqa xmm5, xmm2
+  punpckldq xmm2, xmm3
+  punpckhdq xmm5, xmm3
+  movdqa xmm1, xmm0
+  punpcklqdq xmm0, xmm2
+  punpckhqdq xmm1, xmm2
+  movdqa xmm3, xmm4
+  punpcklqdq xmm4, xmm5
+  punpckhqdq xmm3, xmm5
+  movdqa oword [rsp + 0], xmm0
+  movdqa oword [rsp + 16], xmm1
+  movdqa oword [rsp + 32], xmm4
+  movdqa oword [rsp + 48], xmm3
+
+  // Words 4..7
+  movdqu xmm0, oword [rcx + rbp + 16]
+  movdqu xmm1, oword [rcx + rbp + 1040]
+  movdqu xmm2, oword [rcx + rbp + 2064]
+  movdqu xmm3, oword [rcx + rbp + 3088]
+  movdqa xmm4, xmm0
+  punpckldq xmm0, xmm1
+  punpckhdq xmm4, xmm1
+  movdqa xmm5, xmm2
+  punpckldq xmm2, xmm3
+  punpckhdq xmm5, xmm3
+  movdqa xmm1, xmm0
+  punpcklqdq xmm0, xmm2
+  punpckhqdq xmm1, xmm2
+  movdqa xmm3, xmm4
+  punpcklqdq xmm4, xmm5
+  punpckhqdq xmm3, xmm5
+  movdqa oword [rsp + 64], xmm0
+  movdqa oword [rsp + 80], xmm1
+  movdqa oword [rsp + 96], xmm4
+  movdqa oword [rsp + 112], xmm3
+
+  // Words 8..11
+  movdqu xmm0, oword [rcx + rbp + 32]
+  movdqu xmm1, oword [rcx + rbp + 1056]
+  movdqu xmm2, oword [rcx + rbp + 2080]
+  movdqu xmm3, oword [rcx + rbp + 3104]
+  movdqa xmm4, xmm0
+  punpckldq xmm0, xmm1
+  punpckhdq xmm4, xmm1
+  movdqa xmm5, xmm2
+  punpckldq xmm2, xmm3
+  punpckhdq xmm5, xmm3
+  movdqa xmm1, xmm0
+  punpcklqdq xmm0, xmm2
+  punpckhqdq xmm1, xmm2
+  movdqa xmm3, xmm4
+  punpcklqdq xmm4, xmm5
+  punpckhqdq xmm3, xmm5
+  movdqa oword [rsp + 128], xmm0
+  movdqa oword [rsp + 144], xmm1
+  movdqa oword [rsp + 160], xmm4
+  movdqa oword [rsp + 176], xmm3
+
+  // Words 12..15
+  movdqu xmm0, oword [rcx + rbp + 48]
+  movdqu xmm1, oword [rcx + rbp + 1072]
+  movdqu xmm2, oword [rcx + rbp + 2096]
+  movdqu xmm3, oword [rcx + rbp + 3120]
+  movdqa xmm4, xmm0
+  punpckldq xmm0, xmm1
+  punpckhdq xmm4, xmm1
+  movdqa xmm5, xmm2
+  punpckldq xmm2, xmm3
+  punpckhdq xmm5, xmm3
+  movdqa xmm1, xmm0
+  punpcklqdq xmm0, xmm2
+  punpckhqdq xmm1, xmm2
+  movdqa xmm3, xmm4
+  punpcklqdq xmm4, xmm5
+  punpckhqdq xmm3, xmm5
+  movdqa oword [rsp + 192], xmm0
+  movdqa oword [rsp + 208], xmm1
+  movdqa oword [rsp + 224], xmm4
+  movdqa oword [rsp + 240], xmm3
+
+  // Initialize state: v0-v7 from CV, v8-v11 from IV
+  movdqa xmm0, oword [rsp + 320]
+  movdqa xmm1, oword [rsp + 336]
+  movdqa xmm2, oword [rsp + 352]
+  movdqa xmm3, oword [rsp + 368]
+  movdqa xmm4, oword [rsp + 384]
+  movdqa xmm5, oword [rsp + 400]
+  movdqa xmm6, oword [rsp + 416]
+  movdqa xmm7, oword [rsp + 432]
+  movdqa xmm8, oword [rsp + 480]
+  movdqa xmm9, oword [rsp + 496]
+  movdqa xmm10, oword [rsp + 512]
+  movdqa xmm11, oword [rsp + 528]
+
+  // v12-v15: counter, block length, flags
+  movdqa xmm12, oword [rsp + 448]
+  movdqa oword [rsp + 256], xmm12
+  movdqa xmm12, oword [rsp + 464]
+  movdqa oword [rsp + 272], xmm12
+  movdqa xmm12, oword [rsp + 544]
+  movdqa oword [rsp + 288], xmm12
+
+  // Compute per-block flags and broadcast
+  mov eax, dword ptr [rsp + 568]
+  cmp ebx, 0
+  jne @h4_not_first
+  or eax, 1
+@h4_not_first:
+  cmp ebx, 15
+  jne @h4_not_last
+  or eax, 2
+@h4_not_last:
+  movd xmm12, eax
+  pshufd xmm12, xmm12, 0
+  movdqa oword [rsp + 304], xmm12
+
+  // === Round 0 ===
+  // G col (0,4,8,12) m[0],m[1]
+  movdqa xmm12, oword [rsp + 256]
+  paddd xmm0, oword [rsp + 0]
+  paddd xmm0, xmm4
+  pxor xmm12, xmm0
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm8, xmm12
+  pxor xmm4, xmm8
+  movdqa xmm13, xmm4
+  pslld xmm4, 20
+  psrld xmm13, 12
+  por xmm4, xmm13
+  paddd xmm0, oword [rsp + 16]
+  paddd xmm0, xmm4
+  pxor xmm12, xmm0
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm8, xmm12
+  movdqa oword [rsp + 256], xmm12
+  pxor xmm4, xmm8
+  movdqa xmm13, xmm4
+  pslld xmm4, 25
+  psrld xmm13, 7
+  por xmm4, xmm13
+  // G col (1,5,9,13) m[2],m[3]
+  movdqa xmm12, oword [rsp + 272]
+  paddd xmm1, oword [rsp + 32]
+  paddd xmm1, xmm5
+  pxor xmm12, xmm1
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm9, xmm12
+  pxor xmm5, xmm9
+  movdqa xmm13, xmm5
+  pslld xmm5, 20
+  psrld xmm13, 12
+  por xmm5, xmm13
+  paddd xmm1, oword [rsp + 48]
+  paddd xmm1, xmm5
+  pxor xmm12, xmm1
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm9, xmm12
+  movdqa oword [rsp + 272], xmm12
+  pxor xmm5, xmm9
+  movdqa xmm13, xmm5
+  pslld xmm5, 25
+  psrld xmm13, 7
+  por xmm5, xmm13
+  // G col (2,6,10,14) m[4],m[5]
+  movdqa xmm12, oword [rsp + 288]
+  paddd xmm2, oword [rsp + 64]
+  paddd xmm2, xmm6
+  pxor xmm12, xmm2
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm10, xmm12
+  pxor xmm6, xmm10
+  movdqa xmm13, xmm6
+  pslld xmm6, 20
+  psrld xmm13, 12
+  por xmm6, xmm13
+  paddd xmm2, oword [rsp + 80]
+  paddd xmm2, xmm6
+  pxor xmm12, xmm2
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm10, xmm12
+  movdqa oword [rsp + 288], xmm12
+  pxor xmm6, xmm10
+  movdqa xmm13, xmm6
+  pslld xmm6, 25
+  psrld xmm13, 7
+  por xmm6, xmm13
+  // G col (3,7,11,15) m[6],m[7]
+  movdqa xmm12, oword [rsp + 304]
+  paddd xmm3, oword [rsp + 96]
+  paddd xmm3, xmm7
+  pxor xmm12, xmm3
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm11, xmm12
+  pxor xmm7, xmm11
+  movdqa xmm13, xmm7
+  pslld xmm7, 20
+  psrld xmm13, 12
+  por xmm7, xmm13
+  paddd xmm3, oword [rsp + 112]
+  paddd xmm3, xmm7
+  pxor xmm12, xmm3
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm11, xmm12
+  movdqa oword [rsp + 304], xmm12
+  pxor xmm7, xmm11
+  movdqa xmm13, xmm7
+  pslld xmm7, 25
+  psrld xmm13, 7
+  por xmm7, xmm13
+  // G diag (0,5,10,15) m[8],m[9]
+  movdqa xmm12, oword [rsp + 304]
+  paddd xmm0, oword [rsp + 128]
+  paddd xmm0, xmm5
+  pxor xmm12, xmm0
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm10, xmm12
+  pxor xmm5, xmm10
+  movdqa xmm13, xmm5
+  pslld xmm5, 20
+  psrld xmm13, 12
+  por xmm5, xmm13
+  paddd xmm0, oword [rsp + 144]
+  paddd xmm0, xmm5
+  pxor xmm12, xmm0
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm10, xmm12
+  movdqa oword [rsp + 304], xmm12
+  pxor xmm5, xmm10
+  movdqa xmm13, xmm5
+  pslld xmm5, 25
+  psrld xmm13, 7
+  por xmm5, xmm13
+  // G diag (1,6,11,12) m[10],m[11]
+  movdqa xmm12, oword [rsp + 256]
+  paddd xmm1, oword [rsp + 160]
+  paddd xmm1, xmm6
+  pxor xmm12, xmm1
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm11, xmm12
+  pxor xmm6, xmm11
+  movdqa xmm13, xmm6
+  pslld xmm6, 20
+  psrld xmm13, 12
+  por xmm6, xmm13
+  paddd xmm1, oword [rsp + 176]
+  paddd xmm1, xmm6
+  pxor xmm12, xmm1
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm11, xmm12
+  movdqa oword [rsp + 256], xmm12
+  pxor xmm6, xmm11
+  movdqa xmm13, xmm6
+  pslld xmm6, 25
+  psrld xmm13, 7
+  por xmm6, xmm13
+  // G diag (2,7,8,13) m[12],m[13]
+  movdqa xmm12, oword [rsp + 272]
+  paddd xmm2, oword [rsp + 192]
+  paddd xmm2, xmm7
+  pxor xmm12, xmm2
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm8, xmm12
+  pxor xmm7, xmm8
+  movdqa xmm13, xmm7
+  pslld xmm7, 20
+  psrld xmm13, 12
+  por xmm7, xmm13
+  paddd xmm2, oword [rsp + 208]
+  paddd xmm2, xmm7
+  pxor xmm12, xmm2
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm8, xmm12
+  movdqa oword [rsp + 272], xmm12
+  pxor xmm7, xmm8
+  movdqa xmm13, xmm7
+  pslld xmm7, 25
+  psrld xmm13, 7
+  por xmm7, xmm13
+  // G diag (3,4,9,14) m[14],m[15]
+  movdqa xmm12, oword [rsp + 288]
+  paddd xmm3, oword [rsp + 224]
+  paddd xmm3, xmm4
+  pxor xmm12, xmm3
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm9, xmm12
+  pxor xmm4, xmm9
+  movdqa xmm13, xmm4
+  pslld xmm4, 20
+  psrld xmm13, 12
+  por xmm4, xmm13
+  paddd xmm3, oword [rsp + 240]
+  paddd xmm3, xmm4
+  pxor xmm12, xmm3
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm9, xmm12
+  movdqa oword [rsp + 288], xmm12
+  pxor xmm4, xmm9
+  movdqa xmm13, xmm4
+  pslld xmm4, 25
+  psrld xmm13, 7
+  por xmm4, xmm13
+
+  // === Round 1 ===
+  // G col (0,4,8,12) m[2],m[6]
+  movdqa xmm12, oword [rsp + 256]
+  paddd xmm0, oword [rsp + 32]
+  paddd xmm0, xmm4
+  pxor xmm12, xmm0
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm8, xmm12
+  pxor xmm4, xmm8
+  movdqa xmm13, xmm4
+  pslld xmm4, 20
+  psrld xmm13, 12
+  por xmm4, xmm13
+  paddd xmm0, oword [rsp + 96]
+  paddd xmm0, xmm4
+  pxor xmm12, xmm0
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm8, xmm12
+  movdqa oword [rsp + 256], xmm12
+  pxor xmm4, xmm8
+  movdqa xmm13, xmm4
+  pslld xmm4, 25
+  psrld xmm13, 7
+  por xmm4, xmm13
+  // G col (1,5,9,13) m[3],m[10]
+  movdqa xmm12, oword [rsp + 272]
+  paddd xmm1, oword [rsp + 48]
+  paddd xmm1, xmm5
+  pxor xmm12, xmm1
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm9, xmm12
+  pxor xmm5, xmm9
+  movdqa xmm13, xmm5
+  pslld xmm5, 20
+  psrld xmm13, 12
+  por xmm5, xmm13
+  paddd xmm1, oword [rsp + 160]
+  paddd xmm1, xmm5
+  pxor xmm12, xmm1
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm9, xmm12
+  movdqa oword [rsp + 272], xmm12
+  pxor xmm5, xmm9
+  movdqa xmm13, xmm5
+  pslld xmm5, 25
+  psrld xmm13, 7
+  por xmm5, xmm13
+  // G col (2,6,10,14) m[7],m[0]
+  movdqa xmm12, oword [rsp + 288]
+  paddd xmm2, oword [rsp + 112]
+  paddd xmm2, xmm6
+  pxor xmm12, xmm2
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm10, xmm12
+  pxor xmm6, xmm10
+  movdqa xmm13, xmm6
+  pslld xmm6, 20
+  psrld xmm13, 12
+  por xmm6, xmm13
+  paddd xmm2, oword [rsp + 0]
+  paddd xmm2, xmm6
+  pxor xmm12, xmm2
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm10, xmm12
+  movdqa oword [rsp + 288], xmm12
+  pxor xmm6, xmm10
+  movdqa xmm13, xmm6
+  pslld xmm6, 25
+  psrld xmm13, 7
+  por xmm6, xmm13
+  // G col (3,7,11,15) m[4],m[13]
+  movdqa xmm12, oword [rsp + 304]
+  paddd xmm3, oword [rsp + 64]
+  paddd xmm3, xmm7
+  pxor xmm12, xmm3
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm11, xmm12
+  pxor xmm7, xmm11
+  movdqa xmm13, xmm7
+  pslld xmm7, 20
+  psrld xmm13, 12
+  por xmm7, xmm13
+  paddd xmm3, oword [rsp + 208]
+  paddd xmm3, xmm7
+  pxor xmm12, xmm3
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm11, xmm12
+  movdqa oword [rsp + 304], xmm12
+  pxor xmm7, xmm11
+  movdqa xmm13, xmm7
+  pslld xmm7, 25
+  psrld xmm13, 7
+  por xmm7, xmm13
+  // G diag (0,5,10,15) m[1],m[11]
+  movdqa xmm12, oword [rsp + 304]
+  paddd xmm0, oword [rsp + 16]
+  paddd xmm0, xmm5
+  pxor xmm12, xmm0
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm10, xmm12
+  pxor xmm5, xmm10
+  movdqa xmm13, xmm5
+  pslld xmm5, 20
+  psrld xmm13, 12
+  por xmm5, xmm13
+  paddd xmm0, oword [rsp + 176]
+  paddd xmm0, xmm5
+  pxor xmm12, xmm0
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm10, xmm12
+  movdqa oword [rsp + 304], xmm12
+  pxor xmm5, xmm10
+  movdqa xmm13, xmm5
+  pslld xmm5, 25
+  psrld xmm13, 7
+  por xmm5, xmm13
+  // G diag (1,6,11,12) m[12],m[5]
+  movdqa xmm12, oword [rsp + 256]
+  paddd xmm1, oword [rsp + 192]
+  paddd xmm1, xmm6
+  pxor xmm12, xmm1
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm11, xmm12
+  pxor xmm6, xmm11
+  movdqa xmm13, xmm6
+  pslld xmm6, 20
+  psrld xmm13, 12
+  por xmm6, xmm13
+  paddd xmm1, oword [rsp + 80]
+  paddd xmm1, xmm6
+  pxor xmm12, xmm1
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm11, xmm12
+  movdqa oword [rsp + 256], xmm12
+  pxor xmm6, xmm11
+  movdqa xmm13, xmm6
+  pslld xmm6, 25
+  psrld xmm13, 7
+  por xmm6, xmm13
+  // G diag (2,7,8,13) m[9],m[14]
+  movdqa xmm12, oword [rsp + 272]
+  paddd xmm2, oword [rsp + 144]
+  paddd xmm2, xmm7
+  pxor xmm12, xmm2
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm8, xmm12
+  pxor xmm7, xmm8
+  movdqa xmm13, xmm7
+  pslld xmm7, 20
+  psrld xmm13, 12
+  por xmm7, xmm13
+  paddd xmm2, oword [rsp + 224]
+  paddd xmm2, xmm7
+  pxor xmm12, xmm2
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm8, xmm12
+  movdqa oword [rsp + 272], xmm12
+  pxor xmm7, xmm8
+  movdqa xmm13, xmm7
+  pslld xmm7, 25
+  psrld xmm13, 7
+  por xmm7, xmm13
+  // G diag (3,4,9,14) m[15],m[8]
+  movdqa xmm12, oword [rsp + 288]
+  paddd xmm3, oword [rsp + 240]
+  paddd xmm3, xmm4
+  pxor xmm12, xmm3
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm9, xmm12
+  pxor xmm4, xmm9
+  movdqa xmm13, xmm4
+  pslld xmm4, 20
+  psrld xmm13, 12
+  por xmm4, xmm13
+  paddd xmm3, oword [rsp + 128]
+  paddd xmm3, xmm4
+  pxor xmm12, xmm3
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm9, xmm12
+  movdqa oword [rsp + 288], xmm12
+  pxor xmm4, xmm9
+  movdqa xmm13, xmm4
+  pslld xmm4, 25
+  psrld xmm13, 7
+  por xmm4, xmm13
+
+  // === Round 2 ===
+  // G col (0,4,8,12) m[3],m[4]
+  movdqa xmm12, oword [rsp + 256]
+  paddd xmm0, oword [rsp + 48]
+  paddd xmm0, xmm4
+  pxor xmm12, xmm0
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm8, xmm12
+  pxor xmm4, xmm8
+  movdqa xmm13, xmm4
+  pslld xmm4, 20
+  psrld xmm13, 12
+  por xmm4, xmm13
+  paddd xmm0, oword [rsp + 64]
+  paddd xmm0, xmm4
+  pxor xmm12, xmm0
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm8, xmm12
+  movdqa oword [rsp + 256], xmm12
+  pxor xmm4, xmm8
+  movdqa xmm13, xmm4
+  pslld xmm4, 25
+  psrld xmm13, 7
+  por xmm4, xmm13
+  // G col (1,5,9,13) m[10],m[12]
+  movdqa xmm12, oword [rsp + 272]
+  paddd xmm1, oword [rsp + 160]
+  paddd xmm1, xmm5
+  pxor xmm12, xmm1
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm9, xmm12
+  pxor xmm5, xmm9
+  movdqa xmm13, xmm5
+  pslld xmm5, 20
+  psrld xmm13, 12
+  por xmm5, xmm13
+  paddd xmm1, oword [rsp + 192]
+  paddd xmm1, xmm5
+  pxor xmm12, xmm1
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm9, xmm12
+  movdqa oword [rsp + 272], xmm12
+  pxor xmm5, xmm9
+  movdqa xmm13, xmm5
+  pslld xmm5, 25
+  psrld xmm13, 7
+  por xmm5, xmm13
+  // G col (2,6,10,14) m[13],m[2]
+  movdqa xmm12, oword [rsp + 288]
+  paddd xmm2, oword [rsp + 208]
+  paddd xmm2, xmm6
+  pxor xmm12, xmm2
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm10, xmm12
+  pxor xmm6, xmm10
+  movdqa xmm13, xmm6
+  pslld xmm6, 20
+  psrld xmm13, 12
+  por xmm6, xmm13
+  paddd xmm2, oword [rsp + 32]
+  paddd xmm2, xmm6
+  pxor xmm12, xmm2
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm10, xmm12
+  movdqa oword [rsp + 288], xmm12
+  pxor xmm6, xmm10
+  movdqa xmm13, xmm6
+  pslld xmm6, 25
+  psrld xmm13, 7
+  por xmm6, xmm13
+  // G col (3,7,11,15) m[7],m[14]
+  movdqa xmm12, oword [rsp + 304]
+  paddd xmm3, oword [rsp + 112]
+  paddd xmm3, xmm7
+  pxor xmm12, xmm3
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm11, xmm12
+  pxor xmm7, xmm11
+  movdqa xmm13, xmm7
+  pslld xmm7, 20
+  psrld xmm13, 12
+  por xmm7, xmm13
+  paddd xmm3, oword [rsp + 224]
+  paddd xmm3, xmm7
+  pxor xmm12, xmm3
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm11, xmm12
+  movdqa oword [rsp + 304], xmm12
+  pxor xmm7, xmm11
+  movdqa xmm13, xmm7
+  pslld xmm7, 25
+  psrld xmm13, 7
+  por xmm7, xmm13
+  // G diag (0,5,10,15) m[6],m[5]
+  movdqa xmm12, oword [rsp + 304]
+  paddd xmm0, oword [rsp + 96]
+  paddd xmm0, xmm5
+  pxor xmm12, xmm0
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm10, xmm12
+  pxor xmm5, xmm10
+  movdqa xmm13, xmm5
+  pslld xmm5, 20
+  psrld xmm13, 12
+  por xmm5, xmm13
+  paddd xmm0, oword [rsp + 80]
+  paddd xmm0, xmm5
+  pxor xmm12, xmm0
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm10, xmm12
+  movdqa oword [rsp + 304], xmm12
+  pxor xmm5, xmm10
+  movdqa xmm13, xmm5
+  pslld xmm5, 25
+  psrld xmm13, 7
+  por xmm5, xmm13
+  // G diag (1,6,11,12) m[9],m[0]
+  movdqa xmm12, oword [rsp + 256]
+  paddd xmm1, oword [rsp + 144]
+  paddd xmm1, xmm6
+  pxor xmm12, xmm1
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm11, xmm12
+  pxor xmm6, xmm11
+  movdqa xmm13, xmm6
+  pslld xmm6, 20
+  psrld xmm13, 12
+  por xmm6, xmm13
+  paddd xmm1, oword [rsp + 0]
+  paddd xmm1, xmm6
+  pxor xmm12, xmm1
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm11, xmm12
+  movdqa oword [rsp + 256], xmm12
+  pxor xmm6, xmm11
+  movdqa xmm13, xmm6
+  pslld xmm6, 25
+  psrld xmm13, 7
+  por xmm6, xmm13
+  // G diag (2,7,8,13) m[11],m[15]
+  movdqa xmm12, oword [rsp + 272]
+  paddd xmm2, oword [rsp + 176]
+  paddd xmm2, xmm7
+  pxor xmm12, xmm2
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm8, xmm12
+  pxor xmm7, xmm8
+  movdqa xmm13, xmm7
+  pslld xmm7, 20
+  psrld xmm13, 12
+  por xmm7, xmm13
+  paddd xmm2, oword [rsp + 240]
+  paddd xmm2, xmm7
+  pxor xmm12, xmm2
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm8, xmm12
+  movdqa oword [rsp + 272], xmm12
+  pxor xmm7, xmm8
+  movdqa xmm13, xmm7
+  pslld xmm7, 25
+  psrld xmm13, 7
+  por xmm7, xmm13
+  // G diag (3,4,9,14) m[8],m[1]
+  movdqa xmm12, oword [rsp + 288]
+  paddd xmm3, oword [rsp + 128]
+  paddd xmm3, xmm4
+  pxor xmm12, xmm3
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm9, xmm12
+  pxor xmm4, xmm9
+  movdqa xmm13, xmm4
+  pslld xmm4, 20
+  psrld xmm13, 12
+  por xmm4, xmm13
+  paddd xmm3, oword [rsp + 16]
+  paddd xmm3, xmm4
+  pxor xmm12, xmm3
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm9, xmm12
+  movdqa oword [rsp + 288], xmm12
+  pxor xmm4, xmm9
+  movdqa xmm13, xmm4
+  pslld xmm4, 25
+  psrld xmm13, 7
+  por xmm4, xmm13
+
+  // === Round 3 ===
+  // G col (0,4,8,12) m[10],m[7]
+  movdqa xmm12, oword [rsp + 256]
+  paddd xmm0, oword [rsp + 160]
+  paddd xmm0, xmm4
+  pxor xmm12, xmm0
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm8, xmm12
+  pxor xmm4, xmm8
+  movdqa xmm13, xmm4
+  pslld xmm4, 20
+  psrld xmm13, 12
+  por xmm4, xmm13
+  paddd xmm0, oword [rsp + 112]
+  paddd xmm0, xmm4
+  pxor xmm12, xmm0
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm8, xmm12
+  movdqa oword [rsp + 256], xmm12
+  pxor xmm4, xmm8
+  movdqa xmm13, xmm4
+  pslld xmm4, 25
+  psrld xmm13, 7
+  por xmm4, xmm13
+  // G col (1,5,9,13) m[12],m[9]
+  movdqa xmm12, oword [rsp + 272]
+  paddd xmm1, oword [rsp + 192]
+  paddd xmm1, xmm5
+  pxor xmm12, xmm1
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm9, xmm12
+  pxor xmm5, xmm9
+  movdqa xmm13, xmm5
+  pslld xmm5, 20
+  psrld xmm13, 12
+  por xmm5, xmm13
+  paddd xmm1, oword [rsp + 144]
+  paddd xmm1, xmm5
+  pxor xmm12, xmm1
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm9, xmm12
+  movdqa oword [rsp + 272], xmm12
+  pxor xmm5, xmm9
+  movdqa xmm13, xmm5
+  pslld xmm5, 25
+  psrld xmm13, 7
+  por xmm5, xmm13
+  // G col (2,6,10,14) m[14],m[3]
+  movdqa xmm12, oword [rsp + 288]
+  paddd xmm2, oword [rsp + 224]
+  paddd xmm2, xmm6
+  pxor xmm12, xmm2
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm10, xmm12
+  pxor xmm6, xmm10
+  movdqa xmm13, xmm6
+  pslld xmm6, 20
+  psrld xmm13, 12
+  por xmm6, xmm13
+  paddd xmm2, oword [rsp + 48]
+  paddd xmm2, xmm6
+  pxor xmm12, xmm2
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm10, xmm12
+  movdqa oword [rsp + 288], xmm12
+  pxor xmm6, xmm10
+  movdqa xmm13, xmm6
+  pslld xmm6, 25
+  psrld xmm13, 7
+  por xmm6, xmm13
+  // G col (3,7,11,15) m[13],m[15]
+  movdqa xmm12, oword [rsp + 304]
+  paddd xmm3, oword [rsp + 208]
+  paddd xmm3, xmm7
+  pxor xmm12, xmm3
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm11, xmm12
+  pxor xmm7, xmm11
+  movdqa xmm13, xmm7
+  pslld xmm7, 20
+  psrld xmm13, 12
+  por xmm7, xmm13
+  paddd xmm3, oword [rsp + 240]
+  paddd xmm3, xmm7
+  pxor xmm12, xmm3
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm11, xmm12
+  movdqa oword [rsp + 304], xmm12
+  pxor xmm7, xmm11
+  movdqa xmm13, xmm7
+  pslld xmm7, 25
+  psrld xmm13, 7
+  por xmm7, xmm13
+  // G diag (0,5,10,15) m[4],m[0]
+  movdqa xmm12, oword [rsp + 304]
+  paddd xmm0, oword [rsp + 64]
+  paddd xmm0, xmm5
+  pxor xmm12, xmm0
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm10, xmm12
+  pxor xmm5, xmm10
+  movdqa xmm13, xmm5
+  pslld xmm5, 20
+  psrld xmm13, 12
+  por xmm5, xmm13
+  paddd xmm0, oword [rsp + 0]
+  paddd xmm0, xmm5
+  pxor xmm12, xmm0
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm10, xmm12
+  movdqa oword [rsp + 304], xmm12
+  pxor xmm5, xmm10
+  movdqa xmm13, xmm5
+  pslld xmm5, 25
+  psrld xmm13, 7
+  por xmm5, xmm13
+  // G diag (1,6,11,12) m[11],m[2]
+  movdqa xmm12, oword [rsp + 256]
+  paddd xmm1, oword [rsp + 176]
+  paddd xmm1, xmm6
+  pxor xmm12, xmm1
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm11, xmm12
+  pxor xmm6, xmm11
+  movdqa xmm13, xmm6
+  pslld xmm6, 20
+  psrld xmm13, 12
+  por xmm6, xmm13
+  paddd xmm1, oword [rsp + 32]
+  paddd xmm1, xmm6
+  pxor xmm12, xmm1
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm11, xmm12
+  movdqa oword [rsp + 256], xmm12
+  pxor xmm6, xmm11
+  movdqa xmm13, xmm6
+  pslld xmm6, 25
+  psrld xmm13, 7
+  por xmm6, xmm13
+  // G diag (2,7,8,13) m[5],m[8]
+  movdqa xmm12, oword [rsp + 272]
+  paddd xmm2, oword [rsp + 80]
+  paddd xmm2, xmm7
+  pxor xmm12, xmm2
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm8, xmm12
+  pxor xmm7, xmm8
+  movdqa xmm13, xmm7
+  pslld xmm7, 20
+  psrld xmm13, 12
+  por xmm7, xmm13
+  paddd xmm2, oword [rsp + 128]
+  paddd xmm2, xmm7
+  pxor xmm12, xmm2
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm8, xmm12
+  movdqa oword [rsp + 272], xmm12
+  pxor xmm7, xmm8
+  movdqa xmm13, xmm7
+  pslld xmm7, 25
+  psrld xmm13, 7
+  por xmm7, xmm13
+  // G diag (3,4,9,14) m[1],m[6]
+  movdqa xmm12, oword [rsp + 288]
+  paddd xmm3, oword [rsp + 16]
+  paddd xmm3, xmm4
+  pxor xmm12, xmm3
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm9, xmm12
+  pxor xmm4, xmm9
+  movdqa xmm13, xmm4
+  pslld xmm4, 20
+  psrld xmm13, 12
+  por xmm4, xmm13
+  paddd xmm3, oword [rsp + 96]
+  paddd xmm3, xmm4
+  pxor xmm12, xmm3
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm9, xmm12
+  movdqa oword [rsp + 288], xmm12
+  pxor xmm4, xmm9
+  movdqa xmm13, xmm4
+  pslld xmm4, 25
+  psrld xmm13, 7
+  por xmm4, xmm13
+
+  // === Round 4 ===
+  // G col (0,4,8,12) m[12],m[13]
+  movdqa xmm12, oword [rsp + 256]
+  paddd xmm0, oword [rsp + 192]
+  paddd xmm0, xmm4
+  pxor xmm12, xmm0
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm8, xmm12
+  pxor xmm4, xmm8
+  movdqa xmm13, xmm4
+  pslld xmm4, 20
+  psrld xmm13, 12
+  por xmm4, xmm13
+  paddd xmm0, oword [rsp + 208]
+  paddd xmm0, xmm4
+  pxor xmm12, xmm0
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm8, xmm12
+  movdqa oword [rsp + 256], xmm12
+  pxor xmm4, xmm8
+  movdqa xmm13, xmm4
+  pslld xmm4, 25
+  psrld xmm13, 7
+  por xmm4, xmm13
+  // G col (1,5,9,13) m[9],m[11]
+  movdqa xmm12, oword [rsp + 272]
+  paddd xmm1, oword [rsp + 144]
+  paddd xmm1, xmm5
+  pxor xmm12, xmm1
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm9, xmm12
+  pxor xmm5, xmm9
+  movdqa xmm13, xmm5
+  pslld xmm5, 20
+  psrld xmm13, 12
+  por xmm5, xmm13
+  paddd xmm1, oword [rsp + 176]
+  paddd xmm1, xmm5
+  pxor xmm12, xmm1
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm9, xmm12
+  movdqa oword [rsp + 272], xmm12
+  pxor xmm5, xmm9
+  movdqa xmm13, xmm5
+  pslld xmm5, 25
+  psrld xmm13, 7
+  por xmm5, xmm13
+  // G col (2,6,10,14) m[15],m[10]
+  movdqa xmm12, oword [rsp + 288]
+  paddd xmm2, oword [rsp + 240]
+  paddd xmm2, xmm6
+  pxor xmm12, xmm2
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm10, xmm12
+  pxor xmm6, xmm10
+  movdqa xmm13, xmm6
+  pslld xmm6, 20
+  psrld xmm13, 12
+  por xmm6, xmm13
+  paddd xmm2, oword [rsp + 160]
+  paddd xmm2, xmm6
+  pxor xmm12, xmm2
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm10, xmm12
+  movdqa oword [rsp + 288], xmm12
+  pxor xmm6, xmm10
+  movdqa xmm13, xmm6
+  pslld xmm6, 25
+  psrld xmm13, 7
+  por xmm6, xmm13
+  // G col (3,7,11,15) m[14],m[8]
+  movdqa xmm12, oword [rsp + 304]
+  paddd xmm3, oword [rsp + 224]
+  paddd xmm3, xmm7
+  pxor xmm12, xmm3
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm11, xmm12
+  pxor xmm7, xmm11
+  movdqa xmm13, xmm7
+  pslld xmm7, 20
+  psrld xmm13, 12
+  por xmm7, xmm13
+  paddd xmm3, oword [rsp + 128]
+  paddd xmm3, xmm7
+  pxor xmm12, xmm3
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm11, xmm12
+  movdqa oword [rsp + 304], xmm12
+  pxor xmm7, xmm11
+  movdqa xmm13, xmm7
+  pslld xmm7, 25
+  psrld xmm13, 7
+  por xmm7, xmm13
+  // G diag (0,5,10,15) m[7],m[2]
+  movdqa xmm12, oword [rsp + 304]
+  paddd xmm0, oword [rsp + 112]
+  paddd xmm0, xmm5
+  pxor xmm12, xmm0
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm10, xmm12
+  pxor xmm5, xmm10
+  movdqa xmm13, xmm5
+  pslld xmm5, 20
+  psrld xmm13, 12
+  por xmm5, xmm13
+  paddd xmm0, oword [rsp + 32]
+  paddd xmm0, xmm5
+  pxor xmm12, xmm0
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm10, xmm12
+  movdqa oword [rsp + 304], xmm12
+  pxor xmm5, xmm10
+  movdqa xmm13, xmm5
+  pslld xmm5, 25
+  psrld xmm13, 7
+  por xmm5, xmm13
+  // G diag (1,6,11,12) m[5],m[3]
+  movdqa xmm12, oword [rsp + 256]
+  paddd xmm1, oword [rsp + 80]
+  paddd xmm1, xmm6
+  pxor xmm12, xmm1
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm11, xmm12
+  pxor xmm6, xmm11
+  movdqa xmm13, xmm6
+  pslld xmm6, 20
+  psrld xmm13, 12
+  por xmm6, xmm13
+  paddd xmm1, oword [rsp + 48]
+  paddd xmm1, xmm6
+  pxor xmm12, xmm1
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm11, xmm12
+  movdqa oword [rsp + 256], xmm12
+  pxor xmm6, xmm11
+  movdqa xmm13, xmm6
+  pslld xmm6, 25
+  psrld xmm13, 7
+  por xmm6, xmm13
+  // G diag (2,7,8,13) m[0],m[1]
+  movdqa xmm12, oword [rsp + 272]
+  paddd xmm2, oword [rsp + 0]
+  paddd xmm2, xmm7
+  pxor xmm12, xmm2
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm8, xmm12
+  pxor xmm7, xmm8
+  movdqa xmm13, xmm7
+  pslld xmm7, 20
+  psrld xmm13, 12
+  por xmm7, xmm13
+  paddd xmm2, oword [rsp + 16]
+  paddd xmm2, xmm7
+  pxor xmm12, xmm2
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm8, xmm12
+  movdqa oword [rsp + 272], xmm12
+  pxor xmm7, xmm8
+  movdqa xmm13, xmm7
+  pslld xmm7, 25
+  psrld xmm13, 7
+  por xmm7, xmm13
+  // G diag (3,4,9,14) m[6],m[4]
+  movdqa xmm12, oword [rsp + 288]
+  paddd xmm3, oword [rsp + 96]
+  paddd xmm3, xmm4
+  pxor xmm12, xmm3
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm9, xmm12
+  pxor xmm4, xmm9
+  movdqa xmm13, xmm4
+  pslld xmm4, 20
+  psrld xmm13, 12
+  por xmm4, xmm13
+  paddd xmm3, oword [rsp + 64]
+  paddd xmm3, xmm4
+  pxor xmm12, xmm3
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm9, xmm12
+  movdqa oword [rsp + 288], xmm12
+  pxor xmm4, xmm9
+  movdqa xmm13, xmm4
+  pslld xmm4, 25
+  psrld xmm13, 7
+  por xmm4, xmm13
+
+  // === Round 5 ===
+  // G col (0,4,8,12) m[9],m[14]
+  movdqa xmm12, oword [rsp + 256]
+  paddd xmm0, oword [rsp + 144]
+  paddd xmm0, xmm4
+  pxor xmm12, xmm0
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm8, xmm12
+  pxor xmm4, xmm8
+  movdqa xmm13, xmm4
+  pslld xmm4, 20
+  psrld xmm13, 12
+  por xmm4, xmm13
+  paddd xmm0, oword [rsp + 224]
+  paddd xmm0, xmm4
+  pxor xmm12, xmm0
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm8, xmm12
+  movdqa oword [rsp + 256], xmm12
+  pxor xmm4, xmm8
+  movdqa xmm13, xmm4
+  pslld xmm4, 25
+  psrld xmm13, 7
+  por xmm4, xmm13
+  // G col (1,5,9,13) m[11],m[5]
+  movdqa xmm12, oword [rsp + 272]
+  paddd xmm1, oword [rsp + 176]
+  paddd xmm1, xmm5
+  pxor xmm12, xmm1
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm9, xmm12
+  pxor xmm5, xmm9
+  movdqa xmm13, xmm5
+  pslld xmm5, 20
+  psrld xmm13, 12
+  por xmm5, xmm13
+  paddd xmm1, oword [rsp + 80]
+  paddd xmm1, xmm5
+  pxor xmm12, xmm1
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm9, xmm12
+  movdqa oword [rsp + 272], xmm12
+  pxor xmm5, xmm9
+  movdqa xmm13, xmm5
+  pslld xmm5, 25
+  psrld xmm13, 7
+  por xmm5, xmm13
+  // G col (2,6,10,14) m[8],m[12]
+  movdqa xmm12, oword [rsp + 288]
+  paddd xmm2, oword [rsp + 128]
+  paddd xmm2, xmm6
+  pxor xmm12, xmm2
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm10, xmm12
+  pxor xmm6, xmm10
+  movdqa xmm13, xmm6
+  pslld xmm6, 20
+  psrld xmm13, 12
+  por xmm6, xmm13
+  paddd xmm2, oword [rsp + 192]
+  paddd xmm2, xmm6
+  pxor xmm12, xmm2
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm10, xmm12
+  movdqa oword [rsp + 288], xmm12
+  pxor xmm6, xmm10
+  movdqa xmm13, xmm6
+  pslld xmm6, 25
+  psrld xmm13, 7
+  por xmm6, xmm13
+  // G col (3,7,11,15) m[15],m[1]
+  movdqa xmm12, oword [rsp + 304]
+  paddd xmm3, oword [rsp + 240]
+  paddd xmm3, xmm7
+  pxor xmm12, xmm3
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm11, xmm12
+  pxor xmm7, xmm11
+  movdqa xmm13, xmm7
+  pslld xmm7, 20
+  psrld xmm13, 12
+  por xmm7, xmm13
+  paddd xmm3, oword [rsp + 16]
+  paddd xmm3, xmm7
+  pxor xmm12, xmm3
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm11, xmm12
+  movdqa oword [rsp + 304], xmm12
+  pxor xmm7, xmm11
+  movdqa xmm13, xmm7
+  pslld xmm7, 25
+  psrld xmm13, 7
+  por xmm7, xmm13
+  // G diag (0,5,10,15) m[13],m[3]
+  movdqa xmm12, oword [rsp + 304]
+  paddd xmm0, oword [rsp + 208]
+  paddd xmm0, xmm5
+  pxor xmm12, xmm0
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm10, xmm12
+  pxor xmm5, xmm10
+  movdqa xmm13, xmm5
+  pslld xmm5, 20
+  psrld xmm13, 12
+  por xmm5, xmm13
+  paddd xmm0, oword [rsp + 48]
+  paddd xmm0, xmm5
+  pxor xmm12, xmm0
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm10, xmm12
+  movdqa oword [rsp + 304], xmm12
+  pxor xmm5, xmm10
+  movdqa xmm13, xmm5
+  pslld xmm5, 25
+  psrld xmm13, 7
+  por xmm5, xmm13
+  // G diag (1,6,11,12) m[0],m[10]
+  movdqa xmm12, oword [rsp + 256]
+  paddd xmm1, oword [rsp + 0]
+  paddd xmm1, xmm6
+  pxor xmm12, xmm1
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm11, xmm12
+  pxor xmm6, xmm11
+  movdqa xmm13, xmm6
+  pslld xmm6, 20
+  psrld xmm13, 12
+  por xmm6, xmm13
+  paddd xmm1, oword [rsp + 160]
+  paddd xmm1, xmm6
+  pxor xmm12, xmm1
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm11, xmm12
+  movdqa oword [rsp + 256], xmm12
+  pxor xmm6, xmm11
+  movdqa xmm13, xmm6
+  pslld xmm6, 25
+  psrld xmm13, 7
+  por xmm6, xmm13
+  // G diag (2,7,8,13) m[2],m[6]
+  movdqa xmm12, oword [rsp + 272]
+  paddd xmm2, oword [rsp + 32]
+  paddd xmm2, xmm7
+  pxor xmm12, xmm2
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm8, xmm12
+  pxor xmm7, xmm8
+  movdqa xmm13, xmm7
+  pslld xmm7, 20
+  psrld xmm13, 12
+  por xmm7, xmm13
+  paddd xmm2, oword [rsp + 96]
+  paddd xmm2, xmm7
+  pxor xmm12, xmm2
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm8, xmm12
+  movdqa oword [rsp + 272], xmm12
+  pxor xmm7, xmm8
+  movdqa xmm13, xmm7
+  pslld xmm7, 25
+  psrld xmm13, 7
+  por xmm7, xmm13
+  // G diag (3,4,9,14) m[4],m[7]
+  movdqa xmm12, oword [rsp + 288]
+  paddd xmm3, oword [rsp + 64]
+  paddd xmm3, xmm4
+  pxor xmm12, xmm3
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm9, xmm12
+  pxor xmm4, xmm9
+  movdqa xmm13, xmm4
+  pslld xmm4, 20
+  psrld xmm13, 12
+  por xmm4, xmm13
+  paddd xmm3, oword [rsp + 112]
+  paddd xmm3, xmm4
+  pxor xmm12, xmm3
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm9, xmm12
+  movdqa oword [rsp + 288], xmm12
+  pxor xmm4, xmm9
+  movdqa xmm13, xmm4
+  pslld xmm4, 25
+  psrld xmm13, 7
+  por xmm4, xmm13
+
+  // === Round 6 ===
+  // G col (0,4,8,12) m[11],m[15]
+  movdqa xmm12, oword [rsp + 256]
+  paddd xmm0, oword [rsp + 176]
+  paddd xmm0, xmm4
+  pxor xmm12, xmm0
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm8, xmm12
+  pxor xmm4, xmm8
+  movdqa xmm13, xmm4
+  pslld xmm4, 20
+  psrld xmm13, 12
+  por xmm4, xmm13
+  paddd xmm0, oword [rsp + 240]
+  paddd xmm0, xmm4
+  pxor xmm12, xmm0
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm8, xmm12
+  movdqa oword [rsp + 256], xmm12
+  pxor xmm4, xmm8
+  movdqa xmm13, xmm4
+  pslld xmm4, 25
+  psrld xmm13, 7
+  por xmm4, xmm13
+  // G col (1,5,9,13) m[5],m[0]
+  movdqa xmm12, oword [rsp + 272]
+  paddd xmm1, oword [rsp + 80]
+  paddd xmm1, xmm5
+  pxor xmm12, xmm1
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm9, xmm12
+  pxor xmm5, xmm9
+  movdqa xmm13, xmm5
+  pslld xmm5, 20
+  psrld xmm13, 12
+  por xmm5, xmm13
+  paddd xmm1, oword [rsp + 0]
+  paddd xmm1, xmm5
+  pxor xmm12, xmm1
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm9, xmm12
+  movdqa oword [rsp + 272], xmm12
+  pxor xmm5, xmm9
+  movdqa xmm13, xmm5
+  pslld xmm5, 25
+  psrld xmm13, 7
+  por xmm5, xmm13
+  // G col (2,6,10,14) m[1],m[9]
+  movdqa xmm12, oword [rsp + 288]
+  paddd xmm2, oword [rsp + 16]
+  paddd xmm2, xmm6
+  pxor xmm12, xmm2
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm10, xmm12
+  pxor xmm6, xmm10
+  movdqa xmm13, xmm6
+  pslld xmm6, 20
+  psrld xmm13, 12
+  por xmm6, xmm13
+  paddd xmm2, oword [rsp + 144]
+  paddd xmm2, xmm6
+  pxor xmm12, xmm2
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm10, xmm12
+  movdqa oword [rsp + 288], xmm12
+  pxor xmm6, xmm10
+  movdqa xmm13, xmm6
+  pslld xmm6, 25
+  psrld xmm13, 7
+  por xmm6, xmm13
+  // G col (3,7,11,15) m[8],m[6]
+  movdqa xmm12, oword [rsp + 304]
+  paddd xmm3, oword [rsp + 128]
+  paddd xmm3, xmm7
+  pxor xmm12, xmm3
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm11, xmm12
+  pxor xmm7, xmm11
+  movdqa xmm13, xmm7
+  pslld xmm7, 20
+  psrld xmm13, 12
+  por xmm7, xmm13
+  paddd xmm3, oword [rsp + 96]
+  paddd xmm3, xmm7
+  pxor xmm12, xmm3
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm11, xmm12
+  movdqa oword [rsp + 304], xmm12
+  pxor xmm7, xmm11
+  movdqa xmm13, xmm7
+  pslld xmm7, 25
+  psrld xmm13, 7
+  por xmm7, xmm13
+  // G diag (0,5,10,15) m[14],m[10]
+  movdqa xmm12, oword [rsp + 304]
+  paddd xmm0, oword [rsp + 224]
+  paddd xmm0, xmm5
+  pxor xmm12, xmm0
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm10, xmm12
+  pxor xmm5, xmm10
+  movdqa xmm13, xmm5
+  pslld xmm5, 20
+  psrld xmm13, 12
+  por xmm5, xmm13
+  paddd xmm0, oword [rsp + 160]
+  paddd xmm0, xmm5
+  pxor xmm12, xmm0
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm10, xmm12
+  movdqa oword [rsp + 304], xmm12
+  pxor xmm5, xmm10
+  movdqa xmm13, xmm5
+  pslld xmm5, 25
+  psrld xmm13, 7
+  por xmm5, xmm13
+  // G diag (1,6,11,12) m[2],m[12]
+  movdqa xmm12, oword [rsp + 256]
+  paddd xmm1, oword [rsp + 32]
+  paddd xmm1, xmm6
+  pxor xmm12, xmm1
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm11, xmm12
+  pxor xmm6, xmm11
+  movdqa xmm13, xmm6
+  pslld xmm6, 20
+  psrld xmm13, 12
+  por xmm6, xmm13
+  paddd xmm1, oword [rsp + 192]
+  paddd xmm1, xmm6
+  pxor xmm12, xmm1
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm11, xmm12
+  movdqa oword [rsp + 256], xmm12
+  pxor xmm6, xmm11
+  movdqa xmm13, xmm6
+  pslld xmm6, 25
+  psrld xmm13, 7
+  por xmm6, xmm13
+  // G diag (2,7,8,13) m[3],m[4]
+  movdqa xmm12, oword [rsp + 272]
+  paddd xmm2, oword [rsp + 48]
+  paddd xmm2, xmm7
+  pxor xmm12, xmm2
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm8, xmm12
+  pxor xmm7, xmm8
+  movdqa xmm13, xmm7
+  pslld xmm7, 20
+  psrld xmm13, 12
+  por xmm7, xmm13
+  paddd xmm2, oword [rsp + 64]
+  paddd xmm2, xmm7
+  pxor xmm12, xmm2
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm8, xmm12
+  movdqa oword [rsp + 272], xmm12
+  pxor xmm7, xmm8
+  movdqa xmm13, xmm7
+  pslld xmm7, 25
+  psrld xmm13, 7
+  por xmm7, xmm13
+  // G diag (3,4,9,14) m[7],m[13]
+  movdqa xmm12, oword [rsp + 288]
+  paddd xmm3, oword [rsp + 112]
+  paddd xmm3, xmm4
+  pxor xmm12, xmm3
+  pshuflw xmm12, xmm12, $B1
+  pshufhw xmm12, xmm12, $B1
+  paddd xmm9, xmm12
+  pxor xmm4, xmm9
+  movdqa xmm13, xmm4
+  pslld xmm4, 20
+  psrld xmm13, 12
+  por xmm4, xmm13
+  paddd xmm3, oword [rsp + 208]
+  paddd xmm3, xmm4
+  pxor xmm12, xmm3
+  movdqa xmm13, xmm12
+  psrld xmm12, 8
+  pslld xmm13, 24
+  por xmm12, xmm13
+  paddd xmm9, xmm12
+  movdqa oword [rsp + 288], xmm12
+  pxor xmm4, xmm9
+  movdqa xmm13, xmm4
+  pslld xmm4, 25
+  psrld xmm13, 7
+  por xmm4, xmm13
+
+  // Finalize: new_cv[i] = v[i] XOR v[i+8]
+  pxor xmm0, xmm8
+  pxor xmm1, xmm9
+  pxor xmm2, xmm10
+  pxor xmm3, xmm11
+  movdqa xmm12, oword [rsp + 256]
+  pxor xmm4, xmm12
+  movdqa xmm12, oword [rsp + 272]
+  pxor xmm5, xmm12
+  movdqa xmm12, oword [rsp + 288]
+  pxor xmm6, xmm12
+  movdqa xmm12, oword [rsp + 304]
+  pxor xmm7, xmm12
+
+  // Store new CV
+  movdqa oword [rsp + 320], xmm0
+  movdqa oword [rsp + 336], xmm1
+  movdqa oword [rsp + 352], xmm2
+  movdqa oword [rsp + 368], xmm3
+  movdqa oword [rsp + 384], xmm4
+  movdqa oword [rsp + 400], xmm5
+  movdqa oword [rsp + 416], xmm6
+  movdqa oword [rsp + 432], xmm7
+
+  add ebp, 64
+  inc ebx
+  cmp ebx, 16
+  jb @block_loop
+
+  // Output: transpose 4x8 CV back to per-chunk layout
+  mov rax, qword ptr [rsp + 560]
+
+  // Transpose words 0-3
+  movdqa xmm0, oword [rsp + 320]
+  movdqa xmm1, oword [rsp + 336]
+  movdqa xmm2, oword [rsp + 352]
+  movdqa xmm3, oword [rsp + 368]
+  movdqa xmm4, xmm0
+  punpckldq xmm0, xmm1
+  punpckhdq xmm4, xmm1
+  movdqa xmm5, xmm2
+  punpckldq xmm2, xmm3
+  punpckhdq xmm5, xmm3
+  movdqa xmm1, xmm0
+  punpcklqdq xmm0, xmm2
+  punpckhqdq xmm1, xmm2
+  movdqa xmm3, xmm4
+  punpcklqdq xmm4, xmm5
+  punpckhqdq xmm3, xmm5
+  movdqu oword [rax], xmm0
+  movdqu oword [rax + 32], xmm1
+  movdqu oword [rax + 64], xmm4
+  movdqu oword [rax + 96], xmm3
+
+  // Transpose words 4-7
+  movdqa xmm0, oword [rsp + 384]
+  movdqa xmm1, oword [rsp + 400]
+  movdqa xmm2, oword [rsp + 416]
+  movdqa xmm3, oword [rsp + 432]
+  movdqa xmm4, xmm0
+  punpckldq xmm0, xmm1
+  punpckhdq xmm4, xmm1
+  movdqa xmm5, xmm2
+  punpckldq xmm2, xmm3
+  punpckhdq xmm5, xmm3
+  movdqa xmm1, xmm0
+  punpcklqdq xmm0, xmm2
+  punpckhqdq xmm1, xmm2
+  movdqa xmm3, xmm4
+  punpcklqdq xmm4, xmm5
+  punpckhqdq xmm3, xmm5
+  movdqu oword [rax + 16], xmm0
+  movdqu oword [rax + 48], xmm1
+  movdqu oword [rax + 80], xmm4
+  movdqu oword [rax + 112], xmm3
+
+{$IFDEF MSWINDOWS}
+  movdqa xmm6, oword [rsp + 576]
+  movdqa xmm7, oword [rsp + 592]
+  movdqa xmm8, oword [rsp + 608]
+  movdqa xmm9, oword [rsp + 624]
+  movdqa xmm10, oword [rsp + 640]
+  movdqa xmm11, oword [rsp + 656]
+  movdqa xmm12, oword [rsp + 672]
+  movdqa xmm13, oword [rsp + 688]
+  add rsp, 712
+{$ELSE}
+  add rsp, 584
+{$ENDIF}
+
+  pop rbp
+  pop rbx

--- a/HashLib/src/Include/Simd/Blake3/Blake3Hash8Avx2.inc
+++ b/HashLib/src/Include/Simd/Blake3/Blake3Hash8Avx2.inc
@@ -1,0 +1,1698 @@
+// AVX2 implementation of BLAKE3 hash8: processes 8 independent chunks simultaneously.
+// Reference: BLAKE3-team/BLAKE3 official AVX2 implementation (blake3_avx2.c / blake3_hash_many).
+// Each YMM register holds the same 32-bit word from 8 different chunks (inter-chunk SIMD).
+// All VEX instructions are db-encoded for broad assembler compatibility.
+// 7 rounds per block fully unrolled; 16-block loop with branch for chunk start/end flags.
+//
+// After SimdProc6Begin.inc:
+//   rcx = AInput, rdx = AKey, r8 = AOut,
+//   r9 = ANumChunks, r10 = ACounter, r11 = AFlags
+//
+// Register map: ymm0-ymm7 = state v0-v7, ymm8-ymm11 = state v8-v11,
+//   ymm12-ymm13 = temp, v12-v15 spilled to stack.
+// GPR: rcx = input pointer, rbx = block counter (0..15), rbp = block byte offset.
+// Message transpose: chunks paired (0+4, 1+5, ...) via vinserti128, then per-lane 4x4.
+// Output transpose: full 8x8 via vperm2i128 + vpunpckl/hdq + vpunpcklq/hqdq.
+// 3-operand VEX form eliminates movdqa copies needed in SSE2 rotations.
+// Stack 32-byte aligned via "and rsp, -32" for YMM movdqu stores.
+
+  push rbx
+  push rbp
+  push r12
+
+  mov r12, rsp
+  and rsp, -32
+
+{$IFDEF MSWINDOWS}
+  sub rsp, 1280
+  db $C5, $FA, $7F, $B4, $24, $80, $04, $00, $00 // vmovdqu [rsp+1152], xmm6
+  db $C5, $FA, $7F, $BC, $24, $90, $04, $00, $00 // vmovdqu [rsp+1168], xmm7
+  db $C5, $7A, $7F, $84, $24, $A0, $04, $00, $00 // vmovdqu [rsp+1184], xmm8
+  db $C5, $7A, $7F, $8C, $24, $B0, $04, $00, $00 // vmovdqu [rsp+1200], xmm9
+  db $C5, $7A, $7F, $94, $24, $C0, $04, $00, $00 // vmovdqu [rsp+1216], xmm10
+  db $C5, $7A, $7F, $9C, $24, $D0, $04, $00, $00 // vmovdqu [rsp+1232], xmm11
+  db $C5, $7A, $7F, $A4, $24, $E0, $04, $00, $00 // vmovdqu [rsp+1248], xmm12
+  db $C5, $7A, $7F, $AC, $24, $F0, $04, $00, $00 // vmovdqu [rsp+1264], xmm13
+{$ELSE}
+  sub rsp, 1152
+{$ENDIF}
+
+  mov qword ptr [rsp + 1136], r12
+  mov qword ptr [rsp + 1120], r8
+  mov dword ptr [rsp + 1128], r11d
+
+  // Broadcast key words to CV registers
+  db $C4, $E2, $7D, $58, $02                 // vpbroadcastd ymm0, [rdx+0]
+  db $C4, $E2, $7D, $58, $4A, $04            // vpbroadcastd ymm1, [rdx+4]
+  db $C4, $E2, $7D, $58, $52, $08            // vpbroadcastd ymm2, [rdx+8]
+  db $C4, $E2, $7D, $58, $5A, $0C            // vpbroadcastd ymm3, [rdx+12]
+  db $C4, $E2, $7D, $58, $62, $10            // vpbroadcastd ymm4, [rdx+16]
+  db $C4, $E2, $7D, $58, $6A, $14            // vpbroadcastd ymm5, [rdx+20]
+  db $C4, $E2, $7D, $58, $72, $18            // vpbroadcastd ymm6, [rdx+24]
+  db $C4, $E2, $7D, $58, $7A, $1C            // vpbroadcastd ymm7, [rdx+28]
+
+  // Save initial CV to stack
+  db $C5, $FE, $7F, $84, $24, $80, $02, $00, $00 // vmovdqu [rsp+640], ymm0
+  db $C5, $FE, $7F, $8C, $24, $A0, $02, $00, $00 // vmovdqu [rsp+672], ymm1
+  db $C5, $FE, $7F, $94, $24, $C0, $02, $00, $00 // vmovdqu [rsp+704], ymm2
+  db $C5, $FE, $7F, $9C, $24, $E0, $02, $00, $00 // vmovdqu [rsp+736], ymm3
+  db $C5, $FE, $7F, $A4, $24, $00, $03, $00, $00 // vmovdqu [rsp+768], ymm4
+  db $C5, $FE, $7F, $AC, $24, $20, $03, $00, $00 // vmovdqu [rsp+800], ymm5
+  db $C5, $FE, $7F, $B4, $24, $40, $03, $00, $00 // vmovdqu [rsp+832], ymm6
+  db $C5, $FE, $7F, $BC, $24, $60, $03, $00, $00 // vmovdqu [rsp+864], ymm7
+
+  // Build counter vectors (r10 = ACounter, 64-bit)
+  mov rax, r10
+  mov dword ptr [rsp + 896], eax
+  shr rax, 32
+  mov dword ptr [rsp + 928], eax
+  lea rax, [r10 + 1]
+  mov dword ptr [rsp + 900], eax
+  shr rax, 32
+  mov dword ptr [rsp + 932], eax
+  lea rax, [r10 + 2]
+  mov dword ptr [rsp + 904], eax
+  shr rax, 32
+  mov dword ptr [rsp + 936], eax
+  lea rax, [r10 + 3]
+  mov dword ptr [rsp + 908], eax
+  shr rax, 32
+  mov dword ptr [rsp + 940], eax
+  lea rax, [r10 + 4]
+  mov dword ptr [rsp + 912], eax
+  shr rax, 32
+  mov dword ptr [rsp + 944], eax
+  lea rax, [r10 + 5]
+  mov dword ptr [rsp + 916], eax
+  shr rax, 32
+  mov dword ptr [rsp + 948], eax
+  lea rax, [r10 + 6]
+  mov dword ptr [rsp + 920], eax
+  shr rax, 32
+  mov dword ptr [rsp + 952], eax
+  lea rax, [r10 + 7]
+  mov dword ptr [rsp + 924], eax
+  shr rax, 32
+  mov dword ptr [rsp + 956], eax
+
+  // Pre-compute IV broadcast vectors
+  mov eax, $6A09E667
+  db $C5, $79, $6E, $E0                      // vmovd xmm12, eax
+  db $C4, $42, $7D, $58, $E4                 // vpbroadcastd ymm12, xmm12
+  db $C5, $7E, $7F, $A4, $24, $C0, $03, $00, $00 // vmovdqu [rsp+960], ymm12
+  mov eax, $BB67AE85
+  db $C5, $79, $6E, $E0                      // vmovd xmm12, eax
+  db $C4, $42, $7D, $58, $E4                 // vpbroadcastd ymm12, xmm12
+  db $C5, $7E, $7F, $A4, $24, $E0, $03, $00, $00 // vmovdqu [rsp+992], ymm12
+  mov eax, $3C6EF372
+  db $C5, $79, $6E, $E0                      // vmovd xmm12, eax
+  db $C4, $42, $7D, $58, $E4                 // vpbroadcastd ymm12, xmm12
+  db $C5, $7E, $7F, $A4, $24, $00, $04, $00, $00 // vmovdqu [rsp+1024], ymm12
+  mov eax, $A54FF53A
+  db $C5, $79, $6E, $E0                      // vmovd xmm12, eax
+  db $C4, $42, $7D, $58, $E4                 // vpbroadcastd ymm12, xmm12
+  db $C5, $7E, $7F, $A4, $24, $20, $04, $00, $00 // vmovdqu [rsp+1056], ymm12
+
+  mov eax, 64
+  db $C5, $79, $6E, $E0                      // vmovd xmm12, eax
+  db $C4, $42, $7D, $58, $E4                 // vpbroadcastd ymm12, xmm12
+  db $C5, $7E, $7F, $A4, $24, $40, $04, $00, $00 // vmovdqu [rsp+1088], ymm12
+
+  xor ebx, ebx
+  xor ebp, ebp
+
+@block_loop:
+
+  // Transpose message for current block from 8 chunks
+  // Words 0..3
+  db $C5, $FA, $6F, $04, $29                 // vmovdqu xmm0, [rcx+rbp+0]
+  db $C4, $E3, $7D, $38, $84, $29, $00, $10, $00, $00, $01 // vinserti128 ymm0, ymm0, [rcx+rbp+4096], 1
+  db $C5, $FA, $6F, $8C, $29, $00, $04, $00, $00 // vmovdqu xmm1, [rcx+rbp+1024]
+  db $C4, $E3, $75, $38, $8C, $29, $00, $14, $00, $00, $01 // vinserti128 ymm1, ymm1, [rcx+rbp+5120], 1
+  db $C5, $FA, $6F, $94, $29, $00, $08, $00, $00 // vmovdqu xmm2, [rcx+rbp+2048]
+  db $C4, $E3, $6D, $38, $94, $29, $00, $18, $00, $00, $01 // vinserti128 ymm2, ymm2, [rcx+rbp+6144], 1
+  db $C5, $FA, $6F, $9C, $29, $00, $0C, $00, $00 // vmovdqu xmm3, [rcx+rbp+3072]
+  db $C4, $E3, $65, $38, $9C, $29, $00, $1C, $00, $00, $01 // vinserti128 ymm3, ymm3, [rcx+rbp+7168], 1
+  db $C5, $FD, $62, $E1                      // vpunpckldq ymm4, ymm0, ymm1
+  db $C5, $FD, $6A, $E9                      // vpunpckhdq ymm5, ymm0, ymm1
+  db $C5, $ED, $62, $F3                      // vpunpckldq ymm6, ymm2, ymm3
+  db $C5, $ED, $6A, $FB                      // vpunpckhdq ymm7, ymm2, ymm3
+  db $C5, $DD, $6C, $C6                      // vpunpcklqdq ymm0, ymm4, ymm6
+  db $C5, $DD, $6D, $CE                      // vpunpckhqdq ymm1, ymm4, ymm6
+  db $C5, $D5, $6C, $D7                      // vpunpcklqdq ymm2, ymm5, ymm7
+  db $C5, $D5, $6D, $DF                      // vpunpckhqdq ymm3, ymm5, ymm7
+  db $C5, $FE, $7F, $04, $24                 // vmovdqu [rsp+0], ymm0
+  db $C5, $FE, $7F, $4C, $24, $20            // vmovdqu [rsp+32], ymm1
+  db $C5, $FE, $7F, $54, $24, $40            // vmovdqu [rsp+64], ymm2
+  db $C5, $FE, $7F, $5C, $24, $60            // vmovdqu [rsp+96], ymm3
+
+  // Words 4..7
+  db $C5, $FA, $6F, $44, $29, $10            // vmovdqu xmm0, [rcx+rbp+16]
+  db $C4, $E3, $7D, $38, $84, $29, $10, $10, $00, $00, $01 // vinserti128 ymm0, ymm0, [rcx+rbp+4112], 1
+  db $C5, $FA, $6F, $8C, $29, $10, $04, $00, $00 // vmovdqu xmm1, [rcx+rbp+1040]
+  db $C4, $E3, $75, $38, $8C, $29, $10, $14, $00, $00, $01 // vinserti128 ymm1, ymm1, [rcx+rbp+5136], 1
+  db $C5, $FA, $6F, $94, $29, $10, $08, $00, $00 // vmovdqu xmm2, [rcx+rbp+2064]
+  db $C4, $E3, $6D, $38, $94, $29, $10, $18, $00, $00, $01 // vinserti128 ymm2, ymm2, [rcx+rbp+6160], 1
+  db $C5, $FA, $6F, $9C, $29, $10, $0C, $00, $00 // vmovdqu xmm3, [rcx+rbp+3088]
+  db $C4, $E3, $65, $38, $9C, $29, $10, $1C, $00, $00, $01 // vinserti128 ymm3, ymm3, [rcx+rbp+7184], 1
+  db $C5, $FD, $62, $E1                      // vpunpckldq ymm4, ymm0, ymm1
+  db $C5, $FD, $6A, $E9                      // vpunpckhdq ymm5, ymm0, ymm1
+  db $C5, $ED, $62, $F3                      // vpunpckldq ymm6, ymm2, ymm3
+  db $C5, $ED, $6A, $FB                      // vpunpckhdq ymm7, ymm2, ymm3
+  db $C5, $DD, $6C, $C6                      // vpunpcklqdq ymm0, ymm4, ymm6
+  db $C5, $DD, $6D, $CE                      // vpunpckhqdq ymm1, ymm4, ymm6
+  db $C5, $D5, $6C, $D7                      // vpunpcklqdq ymm2, ymm5, ymm7
+  db $C5, $D5, $6D, $DF                      // vpunpckhqdq ymm3, ymm5, ymm7
+  db $C5, $FE, $7F, $84, $24, $80, $00, $00, $00 // vmovdqu [rsp+128], ymm0
+  db $C5, $FE, $7F, $8C, $24, $A0, $00, $00, $00 // vmovdqu [rsp+160], ymm1
+  db $C5, $FE, $7F, $94, $24, $C0, $00, $00, $00 // vmovdqu [rsp+192], ymm2
+  db $C5, $FE, $7F, $9C, $24, $E0, $00, $00, $00 // vmovdqu [rsp+224], ymm3
+
+  // Words 8..11
+  db $C5, $FA, $6F, $44, $29, $20            // vmovdqu xmm0, [rcx+rbp+32]
+  db $C4, $E3, $7D, $38, $84, $29, $20, $10, $00, $00, $01 // vinserti128 ymm0, ymm0, [rcx+rbp+4128], 1
+  db $C5, $FA, $6F, $8C, $29, $20, $04, $00, $00 // vmovdqu xmm1, [rcx+rbp+1056]
+  db $C4, $E3, $75, $38, $8C, $29, $20, $14, $00, $00, $01 // vinserti128 ymm1, ymm1, [rcx+rbp+5152], 1
+  db $C5, $FA, $6F, $94, $29, $20, $08, $00, $00 // vmovdqu xmm2, [rcx+rbp+2080]
+  db $C4, $E3, $6D, $38, $94, $29, $20, $18, $00, $00, $01 // vinserti128 ymm2, ymm2, [rcx+rbp+6176], 1
+  db $C5, $FA, $6F, $9C, $29, $20, $0C, $00, $00 // vmovdqu xmm3, [rcx+rbp+3104]
+  db $C4, $E3, $65, $38, $9C, $29, $20, $1C, $00, $00, $01 // vinserti128 ymm3, ymm3, [rcx+rbp+7200], 1
+  db $C5, $FD, $62, $E1                      // vpunpckldq ymm4, ymm0, ymm1
+  db $C5, $FD, $6A, $E9                      // vpunpckhdq ymm5, ymm0, ymm1
+  db $C5, $ED, $62, $F3                      // vpunpckldq ymm6, ymm2, ymm3
+  db $C5, $ED, $6A, $FB                      // vpunpckhdq ymm7, ymm2, ymm3
+  db $C5, $DD, $6C, $C6                      // vpunpcklqdq ymm0, ymm4, ymm6
+  db $C5, $DD, $6D, $CE                      // vpunpckhqdq ymm1, ymm4, ymm6
+  db $C5, $D5, $6C, $D7                      // vpunpcklqdq ymm2, ymm5, ymm7
+  db $C5, $D5, $6D, $DF                      // vpunpckhqdq ymm3, ymm5, ymm7
+  db $C5, $FE, $7F, $84, $24, $00, $01, $00, $00 // vmovdqu [rsp+256], ymm0
+  db $C5, $FE, $7F, $8C, $24, $20, $01, $00, $00 // vmovdqu [rsp+288], ymm1
+  db $C5, $FE, $7F, $94, $24, $40, $01, $00, $00 // vmovdqu [rsp+320], ymm2
+  db $C5, $FE, $7F, $9C, $24, $60, $01, $00, $00 // vmovdqu [rsp+352], ymm3
+
+  // Words 12..15
+  db $C5, $FA, $6F, $44, $29, $30            // vmovdqu xmm0, [rcx+rbp+48]
+  db $C4, $E3, $7D, $38, $84, $29, $30, $10, $00, $00, $01 // vinserti128 ymm0, ymm0, [rcx+rbp+4144], 1
+  db $C5, $FA, $6F, $8C, $29, $30, $04, $00, $00 // vmovdqu xmm1, [rcx+rbp+1072]
+  db $C4, $E3, $75, $38, $8C, $29, $30, $14, $00, $00, $01 // vinserti128 ymm1, ymm1, [rcx+rbp+5168], 1
+  db $C5, $FA, $6F, $94, $29, $30, $08, $00, $00 // vmovdqu xmm2, [rcx+rbp+2096]
+  db $C4, $E3, $6D, $38, $94, $29, $30, $18, $00, $00, $01 // vinserti128 ymm2, ymm2, [rcx+rbp+6192], 1
+  db $C5, $FA, $6F, $9C, $29, $30, $0C, $00, $00 // vmovdqu xmm3, [rcx+rbp+3120]
+  db $C4, $E3, $65, $38, $9C, $29, $30, $1C, $00, $00, $01 // vinserti128 ymm3, ymm3, [rcx+rbp+7216], 1
+  db $C5, $FD, $62, $E1                      // vpunpckldq ymm4, ymm0, ymm1
+  db $C5, $FD, $6A, $E9                      // vpunpckhdq ymm5, ymm0, ymm1
+  db $C5, $ED, $62, $F3                      // vpunpckldq ymm6, ymm2, ymm3
+  db $C5, $ED, $6A, $FB                      // vpunpckhdq ymm7, ymm2, ymm3
+  db $C5, $DD, $6C, $C6                      // vpunpcklqdq ymm0, ymm4, ymm6
+  db $C5, $DD, $6D, $CE                      // vpunpckhqdq ymm1, ymm4, ymm6
+  db $C5, $D5, $6C, $D7                      // vpunpcklqdq ymm2, ymm5, ymm7
+  db $C5, $D5, $6D, $DF                      // vpunpckhqdq ymm3, ymm5, ymm7
+  db $C5, $FE, $7F, $84, $24, $80, $01, $00, $00 // vmovdqu [rsp+384], ymm0
+  db $C5, $FE, $7F, $8C, $24, $A0, $01, $00, $00 // vmovdqu [rsp+416], ymm1
+  db $C5, $FE, $7F, $94, $24, $C0, $01, $00, $00 // vmovdqu [rsp+448], ymm2
+  db $C5, $FE, $7F, $9C, $24, $E0, $01, $00, $00 // vmovdqu [rsp+480], ymm3
+
+  // Initialize state: v0-v7 from CV, v8-v11 from IV
+  db $C5, $FE, $6F, $84, $24, $80, $02, $00, $00 // vmovdqu ymm0, [rsp+640]
+  db $C5, $FE, $6F, $8C, $24, $A0, $02, $00, $00 // vmovdqu ymm1, [rsp+672]
+  db $C5, $FE, $6F, $94, $24, $C0, $02, $00, $00 // vmovdqu ymm2, [rsp+704]
+  db $C5, $FE, $6F, $9C, $24, $E0, $02, $00, $00 // vmovdqu ymm3, [rsp+736]
+  db $C5, $FE, $6F, $A4, $24, $00, $03, $00, $00 // vmovdqu ymm4, [rsp+768]
+  db $C5, $FE, $6F, $AC, $24, $20, $03, $00, $00 // vmovdqu ymm5, [rsp+800]
+  db $C5, $FE, $6F, $B4, $24, $40, $03, $00, $00 // vmovdqu ymm6, [rsp+832]
+  db $C5, $FE, $6F, $BC, $24, $60, $03, $00, $00 // vmovdqu ymm7, [rsp+864]
+  db $C5, $7E, $6F, $84, $24, $C0, $03, $00, $00 // vmovdqu ymm8, [rsp+960]
+  db $C5, $7E, $6F, $8C, $24, $E0, $03, $00, $00 // vmovdqu ymm9, [rsp+992]
+  db $C5, $7E, $6F, $94, $24, $00, $04, $00, $00 // vmovdqu ymm10, [rsp+1024]
+  db $C5, $7E, $6F, $9C, $24, $20, $04, $00, $00 // vmovdqu ymm11, [rsp+1056]
+
+  // v12-v15: counter, block length, flags
+  db $C5, $7E, $6F, $A4, $24, $80, $03, $00, $00 // vmovdqu ymm12, [rsp+896]
+  db $C5, $7E, $7F, $A4, $24, $00, $02, $00, $00 // vmovdqu [rsp+512], ymm12
+  db $C5, $7E, $6F, $A4, $24, $A0, $03, $00, $00 // vmovdqu ymm12, [rsp+928]
+  db $C5, $7E, $7F, $A4, $24, $20, $02, $00, $00 // vmovdqu [rsp+544], ymm12
+  db $C5, $7E, $6F, $A4, $24, $40, $04, $00, $00 // vmovdqu ymm12, [rsp+1088]
+  db $C5, $7E, $7F, $A4, $24, $40, $02, $00, $00 // vmovdqu [rsp+576], ymm12
+
+  // Compute per-block flags and broadcast
+  mov eax, dword ptr [rsp + 1128]
+  cmp ebx, 0
+  jne @h8_not_first
+  or eax, 1
+@h8_not_first:
+  cmp ebx, 15
+  jne @h8_not_last
+  or eax, 2
+@h8_not_last:
+  db $C5, $79, $6E, $E0                      // vmovd xmm12, eax
+  db $C4, $42, $7D, $58, $E4                 // vpbroadcastd ymm12, xmm12
+  db $C5, $7E, $7F, $A4, $24, $60, $02, $00, $00 // vmovdqu [rsp+608], ymm12
+
+  // === Round 0 ===
+  // G col (0,4,8,12) m[0],m[1]
+  db $C5, $7E, $6F, $A4, $24, $00, $02, $00, $00 // vmovdqu ymm12, [rsp+512]
+  db $C5, $FD, $FE, $04, $24                 // vpaddd ymm0, ymm0, [rsp+0]
+  db $C5, $FD, $FE, $C4                      // vpaddd ymm0, ymm0, ymm4
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C4, $C1, $5D, $EF, $E0                 // vpxor ymm4, ymm4, ymm8
+  db $C5, $95, $72, $D4, $0C                 // vpsrld ymm13, ymm4, 12
+  db $C5, $DD, $72, $F4, $14                 // vpslld ymm4, ymm4, 20
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+  db $C5, $FD, $FE, $44, $24, $20            // vpaddd ymm0, ymm0, [rsp+32]
+  db $C5, $FD, $FE, $C4                      // vpaddd ymm0, ymm0, ymm4
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C5, $7E, $7F, $A4, $24, $00, $02, $00, $00 // vmovdqu [rsp+512], ymm12
+  db $C4, $C1, $5D, $EF, $E0                 // vpxor ymm4, ymm4, ymm8
+  db $C5, $95, $72, $D4, $07                 // vpsrld ymm13, ymm4, 7
+  db $C5, $DD, $72, $F4, $19                 // vpslld ymm4, ymm4, 25
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+  // G col (1,5,9,13) m[2],m[3]
+  db $C5, $7E, $6F, $A4, $24, $20, $02, $00, $00 // vmovdqu ymm12, [rsp+544]
+  db $C5, $F5, $FE, $4C, $24, $40            // vpaddd ymm1, ymm1, [rsp+64]
+  db $C5, $F5, $FE, $CD                      // vpaddd ymm1, ymm1, ymm5
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C4, $C1, $55, $EF, $E9                 // vpxor ymm5, ymm5, ymm9
+  db $C5, $95, $72, $D5, $0C                 // vpsrld ymm13, ymm5, 12
+  db $C5, $D5, $72, $F5, $14                 // vpslld ymm5, ymm5, 20
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  db $C5, $F5, $FE, $4C, $24, $60            // vpaddd ymm1, ymm1, [rsp+96]
+  db $C5, $F5, $FE, $CD                      // vpaddd ymm1, ymm1, ymm5
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C5, $7E, $7F, $A4, $24, $20, $02, $00, $00 // vmovdqu [rsp+544], ymm12
+  db $C4, $C1, $55, $EF, $E9                 // vpxor ymm5, ymm5, ymm9
+  db $C5, $95, $72, $D5, $07                 // vpsrld ymm13, ymm5, 7
+  db $C5, $D5, $72, $F5, $19                 // vpslld ymm5, ymm5, 25
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  // G col (2,6,10,14) m[4],m[5]
+  db $C5, $7E, $6F, $A4, $24, $40, $02, $00, $00 // vmovdqu ymm12, [rsp+576]
+  db $C5, $ED, $FE, $94, $24, $80, $00, $00, $00 // vpaddd ymm2, ymm2, [rsp+128]
+  db $C5, $ED, $FE, $D6                      // vpaddd ymm2, ymm2, ymm6
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C4, $C1, $4D, $EF, $F2                 // vpxor ymm6, ymm6, ymm10
+  db $C5, $95, $72, $D6, $0C                 // vpsrld ymm13, ymm6, 12
+  db $C5, $CD, $72, $F6, $14                 // vpslld ymm6, ymm6, 20
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  db $C5, $ED, $FE, $94, $24, $A0, $00, $00, $00 // vpaddd ymm2, ymm2, [rsp+160]
+  db $C5, $ED, $FE, $D6                      // vpaddd ymm2, ymm2, ymm6
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C5, $7E, $7F, $A4, $24, $40, $02, $00, $00 // vmovdqu [rsp+576], ymm12
+  db $C4, $C1, $4D, $EF, $F2                 // vpxor ymm6, ymm6, ymm10
+  db $C5, $95, $72, $D6, $07                 // vpsrld ymm13, ymm6, 7
+  db $C5, $CD, $72, $F6, $19                 // vpslld ymm6, ymm6, 25
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  // G col (3,7,11,15) m[6],m[7]
+  db $C5, $7E, $6F, $A4, $24, $60, $02, $00, $00 // vmovdqu ymm12, [rsp+608]
+  db $C5, $E5, $FE, $9C, $24, $C0, $00, $00, $00 // vpaddd ymm3, ymm3, [rsp+192]
+  db $C5, $E5, $FE, $DF                      // vpaddd ymm3, ymm3, ymm7
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C4, $C1, $45, $EF, $FB                 // vpxor ymm7, ymm7, ymm11
+  db $C5, $95, $72, $D7, $0C                 // vpsrld ymm13, ymm7, 12
+  db $C5, $C5, $72, $F7, $14                 // vpslld ymm7, ymm7, 20
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  db $C5, $E5, $FE, $9C, $24, $E0, $00, $00, $00 // vpaddd ymm3, ymm3, [rsp+224]
+  db $C5, $E5, $FE, $DF                      // vpaddd ymm3, ymm3, ymm7
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C5, $7E, $7F, $A4, $24, $60, $02, $00, $00 // vmovdqu [rsp+608], ymm12
+  db $C4, $C1, $45, $EF, $FB                 // vpxor ymm7, ymm7, ymm11
+  db $C5, $95, $72, $D7, $07                 // vpsrld ymm13, ymm7, 7
+  db $C5, $C5, $72, $F7, $19                 // vpslld ymm7, ymm7, 25
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  // G diag (0,5,10,15) m[8],m[9]
+  db $C5, $7E, $6F, $A4, $24, $60, $02, $00, $00 // vmovdqu ymm12, [rsp+608]
+  db $C5, $FD, $FE, $84, $24, $00, $01, $00, $00 // vpaddd ymm0, ymm0, [rsp+256]
+  db $C5, $FD, $FE, $C5                      // vpaddd ymm0, ymm0, ymm5
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C4, $C1, $55, $EF, $EA                 // vpxor ymm5, ymm5, ymm10
+  db $C5, $95, $72, $D5, $0C                 // vpsrld ymm13, ymm5, 12
+  db $C5, $D5, $72, $F5, $14                 // vpslld ymm5, ymm5, 20
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  db $C5, $FD, $FE, $84, $24, $20, $01, $00, $00 // vpaddd ymm0, ymm0, [rsp+288]
+  db $C5, $FD, $FE, $C5                      // vpaddd ymm0, ymm0, ymm5
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C5, $7E, $7F, $A4, $24, $60, $02, $00, $00 // vmovdqu [rsp+608], ymm12
+  db $C4, $C1, $55, $EF, $EA                 // vpxor ymm5, ymm5, ymm10
+  db $C5, $95, $72, $D5, $07                 // vpsrld ymm13, ymm5, 7
+  db $C5, $D5, $72, $F5, $19                 // vpslld ymm5, ymm5, 25
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  // G diag (1,6,11,12) m[10],m[11]
+  db $C5, $7E, $6F, $A4, $24, $00, $02, $00, $00 // vmovdqu ymm12, [rsp+512]
+  db $C5, $F5, $FE, $8C, $24, $40, $01, $00, $00 // vpaddd ymm1, ymm1, [rsp+320]
+  db $C5, $F5, $FE, $CE                      // vpaddd ymm1, ymm1, ymm6
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C4, $C1, $4D, $EF, $F3                 // vpxor ymm6, ymm6, ymm11
+  db $C5, $95, $72, $D6, $0C                 // vpsrld ymm13, ymm6, 12
+  db $C5, $CD, $72, $F6, $14                 // vpslld ymm6, ymm6, 20
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  db $C5, $F5, $FE, $8C, $24, $60, $01, $00, $00 // vpaddd ymm1, ymm1, [rsp+352]
+  db $C5, $F5, $FE, $CE                      // vpaddd ymm1, ymm1, ymm6
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C5, $7E, $7F, $A4, $24, $00, $02, $00, $00 // vmovdqu [rsp+512], ymm12
+  db $C4, $C1, $4D, $EF, $F3                 // vpxor ymm6, ymm6, ymm11
+  db $C5, $95, $72, $D6, $07                 // vpsrld ymm13, ymm6, 7
+  db $C5, $CD, $72, $F6, $19                 // vpslld ymm6, ymm6, 25
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  // G diag (2,7,8,13) m[12],m[13]
+  db $C5, $7E, $6F, $A4, $24, $20, $02, $00, $00 // vmovdqu ymm12, [rsp+544]
+  db $C5, $ED, $FE, $94, $24, $80, $01, $00, $00 // vpaddd ymm2, ymm2, [rsp+384]
+  db $C5, $ED, $FE, $D7                      // vpaddd ymm2, ymm2, ymm7
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C4, $C1, $45, $EF, $F8                 // vpxor ymm7, ymm7, ymm8
+  db $C5, $95, $72, $D7, $0C                 // vpsrld ymm13, ymm7, 12
+  db $C5, $C5, $72, $F7, $14                 // vpslld ymm7, ymm7, 20
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  db $C5, $ED, $FE, $94, $24, $A0, $01, $00, $00 // vpaddd ymm2, ymm2, [rsp+416]
+  db $C5, $ED, $FE, $D7                      // vpaddd ymm2, ymm2, ymm7
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C5, $7E, $7F, $A4, $24, $20, $02, $00, $00 // vmovdqu [rsp+544], ymm12
+  db $C4, $C1, $45, $EF, $F8                 // vpxor ymm7, ymm7, ymm8
+  db $C5, $95, $72, $D7, $07                 // vpsrld ymm13, ymm7, 7
+  db $C5, $C5, $72, $F7, $19                 // vpslld ymm7, ymm7, 25
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  // G diag (3,4,9,14) m[14],m[15]
+  db $C5, $7E, $6F, $A4, $24, $40, $02, $00, $00 // vmovdqu ymm12, [rsp+576]
+  db $C5, $E5, $FE, $9C, $24, $C0, $01, $00, $00 // vpaddd ymm3, ymm3, [rsp+448]
+  db $C5, $E5, $FE, $DC                      // vpaddd ymm3, ymm3, ymm4
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C4, $C1, $5D, $EF, $E1                 // vpxor ymm4, ymm4, ymm9
+  db $C5, $95, $72, $D4, $0C                 // vpsrld ymm13, ymm4, 12
+  db $C5, $DD, $72, $F4, $14                 // vpslld ymm4, ymm4, 20
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+  db $C5, $E5, $FE, $9C, $24, $E0, $01, $00, $00 // vpaddd ymm3, ymm3, [rsp+480]
+  db $C5, $E5, $FE, $DC                      // vpaddd ymm3, ymm3, ymm4
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C5, $7E, $7F, $A4, $24, $40, $02, $00, $00 // vmovdqu [rsp+576], ymm12
+  db $C4, $C1, $5D, $EF, $E1                 // vpxor ymm4, ymm4, ymm9
+  db $C5, $95, $72, $D4, $07                 // vpsrld ymm13, ymm4, 7
+  db $C5, $DD, $72, $F4, $19                 // vpslld ymm4, ymm4, 25
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+
+  // === Round 1 ===
+  // G col (0,4,8,12) m[2],m[6]
+  db $C5, $7E, $6F, $A4, $24, $00, $02, $00, $00 // vmovdqu ymm12, [rsp+512]
+  db $C5, $FD, $FE, $44, $24, $40            // vpaddd ymm0, ymm0, [rsp+64]
+  db $C5, $FD, $FE, $C4                      // vpaddd ymm0, ymm0, ymm4
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C4, $C1, $5D, $EF, $E0                 // vpxor ymm4, ymm4, ymm8
+  db $C5, $95, $72, $D4, $0C                 // vpsrld ymm13, ymm4, 12
+  db $C5, $DD, $72, $F4, $14                 // vpslld ymm4, ymm4, 20
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+  db $C5, $FD, $FE, $84, $24, $C0, $00, $00, $00 // vpaddd ymm0, ymm0, [rsp+192]
+  db $C5, $FD, $FE, $C4                      // vpaddd ymm0, ymm0, ymm4
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C5, $7E, $7F, $A4, $24, $00, $02, $00, $00 // vmovdqu [rsp+512], ymm12
+  db $C4, $C1, $5D, $EF, $E0                 // vpxor ymm4, ymm4, ymm8
+  db $C5, $95, $72, $D4, $07                 // vpsrld ymm13, ymm4, 7
+  db $C5, $DD, $72, $F4, $19                 // vpslld ymm4, ymm4, 25
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+  // G col (1,5,9,13) m[3],m[10]
+  db $C5, $7E, $6F, $A4, $24, $20, $02, $00, $00 // vmovdqu ymm12, [rsp+544]
+  db $C5, $F5, $FE, $4C, $24, $60            // vpaddd ymm1, ymm1, [rsp+96]
+  db $C5, $F5, $FE, $CD                      // vpaddd ymm1, ymm1, ymm5
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C4, $C1, $55, $EF, $E9                 // vpxor ymm5, ymm5, ymm9
+  db $C5, $95, $72, $D5, $0C                 // vpsrld ymm13, ymm5, 12
+  db $C5, $D5, $72, $F5, $14                 // vpslld ymm5, ymm5, 20
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  db $C5, $F5, $FE, $8C, $24, $40, $01, $00, $00 // vpaddd ymm1, ymm1, [rsp+320]
+  db $C5, $F5, $FE, $CD                      // vpaddd ymm1, ymm1, ymm5
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C5, $7E, $7F, $A4, $24, $20, $02, $00, $00 // vmovdqu [rsp+544], ymm12
+  db $C4, $C1, $55, $EF, $E9                 // vpxor ymm5, ymm5, ymm9
+  db $C5, $95, $72, $D5, $07                 // vpsrld ymm13, ymm5, 7
+  db $C5, $D5, $72, $F5, $19                 // vpslld ymm5, ymm5, 25
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  // G col (2,6,10,14) m[7],m[0]
+  db $C5, $7E, $6F, $A4, $24, $40, $02, $00, $00 // vmovdqu ymm12, [rsp+576]
+  db $C5, $ED, $FE, $94, $24, $E0, $00, $00, $00 // vpaddd ymm2, ymm2, [rsp+224]
+  db $C5, $ED, $FE, $D6                      // vpaddd ymm2, ymm2, ymm6
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C4, $C1, $4D, $EF, $F2                 // vpxor ymm6, ymm6, ymm10
+  db $C5, $95, $72, $D6, $0C                 // vpsrld ymm13, ymm6, 12
+  db $C5, $CD, $72, $F6, $14                 // vpslld ymm6, ymm6, 20
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  db $C5, $ED, $FE, $14, $24                 // vpaddd ymm2, ymm2, [rsp+0]
+  db $C5, $ED, $FE, $D6                      // vpaddd ymm2, ymm2, ymm6
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C5, $7E, $7F, $A4, $24, $40, $02, $00, $00 // vmovdqu [rsp+576], ymm12
+  db $C4, $C1, $4D, $EF, $F2                 // vpxor ymm6, ymm6, ymm10
+  db $C5, $95, $72, $D6, $07                 // vpsrld ymm13, ymm6, 7
+  db $C5, $CD, $72, $F6, $19                 // vpslld ymm6, ymm6, 25
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  // G col (3,7,11,15) m[4],m[13]
+  db $C5, $7E, $6F, $A4, $24, $60, $02, $00, $00 // vmovdqu ymm12, [rsp+608]
+  db $C5, $E5, $FE, $9C, $24, $80, $00, $00, $00 // vpaddd ymm3, ymm3, [rsp+128]
+  db $C5, $E5, $FE, $DF                      // vpaddd ymm3, ymm3, ymm7
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C4, $C1, $45, $EF, $FB                 // vpxor ymm7, ymm7, ymm11
+  db $C5, $95, $72, $D7, $0C                 // vpsrld ymm13, ymm7, 12
+  db $C5, $C5, $72, $F7, $14                 // vpslld ymm7, ymm7, 20
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  db $C5, $E5, $FE, $9C, $24, $A0, $01, $00, $00 // vpaddd ymm3, ymm3, [rsp+416]
+  db $C5, $E5, $FE, $DF                      // vpaddd ymm3, ymm3, ymm7
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C5, $7E, $7F, $A4, $24, $60, $02, $00, $00 // vmovdqu [rsp+608], ymm12
+  db $C4, $C1, $45, $EF, $FB                 // vpxor ymm7, ymm7, ymm11
+  db $C5, $95, $72, $D7, $07                 // vpsrld ymm13, ymm7, 7
+  db $C5, $C5, $72, $F7, $19                 // vpslld ymm7, ymm7, 25
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  // G diag (0,5,10,15) m[1],m[11]
+  db $C5, $7E, $6F, $A4, $24, $60, $02, $00, $00 // vmovdqu ymm12, [rsp+608]
+  db $C5, $FD, $FE, $44, $24, $20            // vpaddd ymm0, ymm0, [rsp+32]
+  db $C5, $FD, $FE, $C5                      // vpaddd ymm0, ymm0, ymm5
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C4, $C1, $55, $EF, $EA                 // vpxor ymm5, ymm5, ymm10
+  db $C5, $95, $72, $D5, $0C                 // vpsrld ymm13, ymm5, 12
+  db $C5, $D5, $72, $F5, $14                 // vpslld ymm5, ymm5, 20
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  db $C5, $FD, $FE, $84, $24, $60, $01, $00, $00 // vpaddd ymm0, ymm0, [rsp+352]
+  db $C5, $FD, $FE, $C5                      // vpaddd ymm0, ymm0, ymm5
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C5, $7E, $7F, $A4, $24, $60, $02, $00, $00 // vmovdqu [rsp+608], ymm12
+  db $C4, $C1, $55, $EF, $EA                 // vpxor ymm5, ymm5, ymm10
+  db $C5, $95, $72, $D5, $07                 // vpsrld ymm13, ymm5, 7
+  db $C5, $D5, $72, $F5, $19                 // vpslld ymm5, ymm5, 25
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  // G diag (1,6,11,12) m[12],m[5]
+  db $C5, $7E, $6F, $A4, $24, $00, $02, $00, $00 // vmovdqu ymm12, [rsp+512]
+  db $C5, $F5, $FE, $8C, $24, $80, $01, $00, $00 // vpaddd ymm1, ymm1, [rsp+384]
+  db $C5, $F5, $FE, $CE                      // vpaddd ymm1, ymm1, ymm6
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C4, $C1, $4D, $EF, $F3                 // vpxor ymm6, ymm6, ymm11
+  db $C5, $95, $72, $D6, $0C                 // vpsrld ymm13, ymm6, 12
+  db $C5, $CD, $72, $F6, $14                 // vpslld ymm6, ymm6, 20
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  db $C5, $F5, $FE, $8C, $24, $A0, $00, $00, $00 // vpaddd ymm1, ymm1, [rsp+160]
+  db $C5, $F5, $FE, $CE                      // vpaddd ymm1, ymm1, ymm6
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C5, $7E, $7F, $A4, $24, $00, $02, $00, $00 // vmovdqu [rsp+512], ymm12
+  db $C4, $C1, $4D, $EF, $F3                 // vpxor ymm6, ymm6, ymm11
+  db $C5, $95, $72, $D6, $07                 // vpsrld ymm13, ymm6, 7
+  db $C5, $CD, $72, $F6, $19                 // vpslld ymm6, ymm6, 25
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  // G diag (2,7,8,13) m[9],m[14]
+  db $C5, $7E, $6F, $A4, $24, $20, $02, $00, $00 // vmovdqu ymm12, [rsp+544]
+  db $C5, $ED, $FE, $94, $24, $20, $01, $00, $00 // vpaddd ymm2, ymm2, [rsp+288]
+  db $C5, $ED, $FE, $D7                      // vpaddd ymm2, ymm2, ymm7
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C4, $C1, $45, $EF, $F8                 // vpxor ymm7, ymm7, ymm8
+  db $C5, $95, $72, $D7, $0C                 // vpsrld ymm13, ymm7, 12
+  db $C5, $C5, $72, $F7, $14                 // vpslld ymm7, ymm7, 20
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  db $C5, $ED, $FE, $94, $24, $C0, $01, $00, $00 // vpaddd ymm2, ymm2, [rsp+448]
+  db $C5, $ED, $FE, $D7                      // vpaddd ymm2, ymm2, ymm7
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C5, $7E, $7F, $A4, $24, $20, $02, $00, $00 // vmovdqu [rsp+544], ymm12
+  db $C4, $C1, $45, $EF, $F8                 // vpxor ymm7, ymm7, ymm8
+  db $C5, $95, $72, $D7, $07                 // vpsrld ymm13, ymm7, 7
+  db $C5, $C5, $72, $F7, $19                 // vpslld ymm7, ymm7, 25
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  // G diag (3,4,9,14) m[15],m[8]
+  db $C5, $7E, $6F, $A4, $24, $40, $02, $00, $00 // vmovdqu ymm12, [rsp+576]
+  db $C5, $E5, $FE, $9C, $24, $E0, $01, $00, $00 // vpaddd ymm3, ymm3, [rsp+480]
+  db $C5, $E5, $FE, $DC                      // vpaddd ymm3, ymm3, ymm4
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C4, $C1, $5D, $EF, $E1                 // vpxor ymm4, ymm4, ymm9
+  db $C5, $95, $72, $D4, $0C                 // vpsrld ymm13, ymm4, 12
+  db $C5, $DD, $72, $F4, $14                 // vpslld ymm4, ymm4, 20
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+  db $C5, $E5, $FE, $9C, $24, $00, $01, $00, $00 // vpaddd ymm3, ymm3, [rsp+256]
+  db $C5, $E5, $FE, $DC                      // vpaddd ymm3, ymm3, ymm4
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C5, $7E, $7F, $A4, $24, $40, $02, $00, $00 // vmovdqu [rsp+576], ymm12
+  db $C4, $C1, $5D, $EF, $E1                 // vpxor ymm4, ymm4, ymm9
+  db $C5, $95, $72, $D4, $07                 // vpsrld ymm13, ymm4, 7
+  db $C5, $DD, $72, $F4, $19                 // vpslld ymm4, ymm4, 25
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+
+  // === Round 2 ===
+  // G col (0,4,8,12) m[3],m[4]
+  db $C5, $7E, $6F, $A4, $24, $00, $02, $00, $00 // vmovdqu ymm12, [rsp+512]
+  db $C5, $FD, $FE, $44, $24, $60            // vpaddd ymm0, ymm0, [rsp+96]
+  db $C5, $FD, $FE, $C4                      // vpaddd ymm0, ymm0, ymm4
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C4, $C1, $5D, $EF, $E0                 // vpxor ymm4, ymm4, ymm8
+  db $C5, $95, $72, $D4, $0C                 // vpsrld ymm13, ymm4, 12
+  db $C5, $DD, $72, $F4, $14                 // vpslld ymm4, ymm4, 20
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+  db $C5, $FD, $FE, $84, $24, $80, $00, $00, $00 // vpaddd ymm0, ymm0, [rsp+128]
+  db $C5, $FD, $FE, $C4                      // vpaddd ymm0, ymm0, ymm4
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C5, $7E, $7F, $A4, $24, $00, $02, $00, $00 // vmovdqu [rsp+512], ymm12
+  db $C4, $C1, $5D, $EF, $E0                 // vpxor ymm4, ymm4, ymm8
+  db $C5, $95, $72, $D4, $07                 // vpsrld ymm13, ymm4, 7
+  db $C5, $DD, $72, $F4, $19                 // vpslld ymm4, ymm4, 25
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+  // G col (1,5,9,13) m[10],m[12]
+  db $C5, $7E, $6F, $A4, $24, $20, $02, $00, $00 // vmovdqu ymm12, [rsp+544]
+  db $C5, $F5, $FE, $8C, $24, $40, $01, $00, $00 // vpaddd ymm1, ymm1, [rsp+320]
+  db $C5, $F5, $FE, $CD                      // vpaddd ymm1, ymm1, ymm5
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C4, $C1, $55, $EF, $E9                 // vpxor ymm5, ymm5, ymm9
+  db $C5, $95, $72, $D5, $0C                 // vpsrld ymm13, ymm5, 12
+  db $C5, $D5, $72, $F5, $14                 // vpslld ymm5, ymm5, 20
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  db $C5, $F5, $FE, $8C, $24, $80, $01, $00, $00 // vpaddd ymm1, ymm1, [rsp+384]
+  db $C5, $F5, $FE, $CD                      // vpaddd ymm1, ymm1, ymm5
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C5, $7E, $7F, $A4, $24, $20, $02, $00, $00 // vmovdqu [rsp+544], ymm12
+  db $C4, $C1, $55, $EF, $E9                 // vpxor ymm5, ymm5, ymm9
+  db $C5, $95, $72, $D5, $07                 // vpsrld ymm13, ymm5, 7
+  db $C5, $D5, $72, $F5, $19                 // vpslld ymm5, ymm5, 25
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  // G col (2,6,10,14) m[13],m[2]
+  db $C5, $7E, $6F, $A4, $24, $40, $02, $00, $00 // vmovdqu ymm12, [rsp+576]
+  db $C5, $ED, $FE, $94, $24, $A0, $01, $00, $00 // vpaddd ymm2, ymm2, [rsp+416]
+  db $C5, $ED, $FE, $D6                      // vpaddd ymm2, ymm2, ymm6
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C4, $C1, $4D, $EF, $F2                 // vpxor ymm6, ymm6, ymm10
+  db $C5, $95, $72, $D6, $0C                 // vpsrld ymm13, ymm6, 12
+  db $C5, $CD, $72, $F6, $14                 // vpslld ymm6, ymm6, 20
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  db $C5, $ED, $FE, $54, $24, $40            // vpaddd ymm2, ymm2, [rsp+64]
+  db $C5, $ED, $FE, $D6                      // vpaddd ymm2, ymm2, ymm6
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C5, $7E, $7F, $A4, $24, $40, $02, $00, $00 // vmovdqu [rsp+576], ymm12
+  db $C4, $C1, $4D, $EF, $F2                 // vpxor ymm6, ymm6, ymm10
+  db $C5, $95, $72, $D6, $07                 // vpsrld ymm13, ymm6, 7
+  db $C5, $CD, $72, $F6, $19                 // vpslld ymm6, ymm6, 25
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  // G col (3,7,11,15) m[7],m[14]
+  db $C5, $7E, $6F, $A4, $24, $60, $02, $00, $00 // vmovdqu ymm12, [rsp+608]
+  db $C5, $E5, $FE, $9C, $24, $E0, $00, $00, $00 // vpaddd ymm3, ymm3, [rsp+224]
+  db $C5, $E5, $FE, $DF                      // vpaddd ymm3, ymm3, ymm7
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C4, $C1, $45, $EF, $FB                 // vpxor ymm7, ymm7, ymm11
+  db $C5, $95, $72, $D7, $0C                 // vpsrld ymm13, ymm7, 12
+  db $C5, $C5, $72, $F7, $14                 // vpslld ymm7, ymm7, 20
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  db $C5, $E5, $FE, $9C, $24, $C0, $01, $00, $00 // vpaddd ymm3, ymm3, [rsp+448]
+  db $C5, $E5, $FE, $DF                      // vpaddd ymm3, ymm3, ymm7
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C5, $7E, $7F, $A4, $24, $60, $02, $00, $00 // vmovdqu [rsp+608], ymm12
+  db $C4, $C1, $45, $EF, $FB                 // vpxor ymm7, ymm7, ymm11
+  db $C5, $95, $72, $D7, $07                 // vpsrld ymm13, ymm7, 7
+  db $C5, $C5, $72, $F7, $19                 // vpslld ymm7, ymm7, 25
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  // G diag (0,5,10,15) m[6],m[5]
+  db $C5, $7E, $6F, $A4, $24, $60, $02, $00, $00 // vmovdqu ymm12, [rsp+608]
+  db $C5, $FD, $FE, $84, $24, $C0, $00, $00, $00 // vpaddd ymm0, ymm0, [rsp+192]
+  db $C5, $FD, $FE, $C5                      // vpaddd ymm0, ymm0, ymm5
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C4, $C1, $55, $EF, $EA                 // vpxor ymm5, ymm5, ymm10
+  db $C5, $95, $72, $D5, $0C                 // vpsrld ymm13, ymm5, 12
+  db $C5, $D5, $72, $F5, $14                 // vpslld ymm5, ymm5, 20
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  db $C5, $FD, $FE, $84, $24, $A0, $00, $00, $00 // vpaddd ymm0, ymm0, [rsp+160]
+  db $C5, $FD, $FE, $C5                      // vpaddd ymm0, ymm0, ymm5
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C5, $7E, $7F, $A4, $24, $60, $02, $00, $00 // vmovdqu [rsp+608], ymm12
+  db $C4, $C1, $55, $EF, $EA                 // vpxor ymm5, ymm5, ymm10
+  db $C5, $95, $72, $D5, $07                 // vpsrld ymm13, ymm5, 7
+  db $C5, $D5, $72, $F5, $19                 // vpslld ymm5, ymm5, 25
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  // G diag (1,6,11,12) m[9],m[0]
+  db $C5, $7E, $6F, $A4, $24, $00, $02, $00, $00 // vmovdqu ymm12, [rsp+512]
+  db $C5, $F5, $FE, $8C, $24, $20, $01, $00, $00 // vpaddd ymm1, ymm1, [rsp+288]
+  db $C5, $F5, $FE, $CE                      // vpaddd ymm1, ymm1, ymm6
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C4, $C1, $4D, $EF, $F3                 // vpxor ymm6, ymm6, ymm11
+  db $C5, $95, $72, $D6, $0C                 // vpsrld ymm13, ymm6, 12
+  db $C5, $CD, $72, $F6, $14                 // vpslld ymm6, ymm6, 20
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  db $C5, $F5, $FE, $0C, $24                 // vpaddd ymm1, ymm1, [rsp+0]
+  db $C5, $F5, $FE, $CE                      // vpaddd ymm1, ymm1, ymm6
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C5, $7E, $7F, $A4, $24, $00, $02, $00, $00 // vmovdqu [rsp+512], ymm12
+  db $C4, $C1, $4D, $EF, $F3                 // vpxor ymm6, ymm6, ymm11
+  db $C5, $95, $72, $D6, $07                 // vpsrld ymm13, ymm6, 7
+  db $C5, $CD, $72, $F6, $19                 // vpslld ymm6, ymm6, 25
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  // G diag (2,7,8,13) m[11],m[15]
+  db $C5, $7E, $6F, $A4, $24, $20, $02, $00, $00 // vmovdqu ymm12, [rsp+544]
+  db $C5, $ED, $FE, $94, $24, $60, $01, $00, $00 // vpaddd ymm2, ymm2, [rsp+352]
+  db $C5, $ED, $FE, $D7                      // vpaddd ymm2, ymm2, ymm7
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C4, $C1, $45, $EF, $F8                 // vpxor ymm7, ymm7, ymm8
+  db $C5, $95, $72, $D7, $0C                 // vpsrld ymm13, ymm7, 12
+  db $C5, $C5, $72, $F7, $14                 // vpslld ymm7, ymm7, 20
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  db $C5, $ED, $FE, $94, $24, $E0, $01, $00, $00 // vpaddd ymm2, ymm2, [rsp+480]
+  db $C5, $ED, $FE, $D7                      // vpaddd ymm2, ymm2, ymm7
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C5, $7E, $7F, $A4, $24, $20, $02, $00, $00 // vmovdqu [rsp+544], ymm12
+  db $C4, $C1, $45, $EF, $F8                 // vpxor ymm7, ymm7, ymm8
+  db $C5, $95, $72, $D7, $07                 // vpsrld ymm13, ymm7, 7
+  db $C5, $C5, $72, $F7, $19                 // vpslld ymm7, ymm7, 25
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  // G diag (3,4,9,14) m[8],m[1]
+  db $C5, $7E, $6F, $A4, $24, $40, $02, $00, $00 // vmovdqu ymm12, [rsp+576]
+  db $C5, $E5, $FE, $9C, $24, $00, $01, $00, $00 // vpaddd ymm3, ymm3, [rsp+256]
+  db $C5, $E5, $FE, $DC                      // vpaddd ymm3, ymm3, ymm4
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C4, $C1, $5D, $EF, $E1                 // vpxor ymm4, ymm4, ymm9
+  db $C5, $95, $72, $D4, $0C                 // vpsrld ymm13, ymm4, 12
+  db $C5, $DD, $72, $F4, $14                 // vpslld ymm4, ymm4, 20
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+  db $C5, $E5, $FE, $5C, $24, $20            // vpaddd ymm3, ymm3, [rsp+32]
+  db $C5, $E5, $FE, $DC                      // vpaddd ymm3, ymm3, ymm4
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C5, $7E, $7F, $A4, $24, $40, $02, $00, $00 // vmovdqu [rsp+576], ymm12
+  db $C4, $C1, $5D, $EF, $E1                 // vpxor ymm4, ymm4, ymm9
+  db $C5, $95, $72, $D4, $07                 // vpsrld ymm13, ymm4, 7
+  db $C5, $DD, $72, $F4, $19                 // vpslld ymm4, ymm4, 25
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+
+  // === Round 3 ===
+  // G col (0,4,8,12) m[10],m[7]
+  db $C5, $7E, $6F, $A4, $24, $00, $02, $00, $00 // vmovdqu ymm12, [rsp+512]
+  db $C5, $FD, $FE, $84, $24, $40, $01, $00, $00 // vpaddd ymm0, ymm0, [rsp+320]
+  db $C5, $FD, $FE, $C4                      // vpaddd ymm0, ymm0, ymm4
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C4, $C1, $5D, $EF, $E0                 // vpxor ymm4, ymm4, ymm8
+  db $C5, $95, $72, $D4, $0C                 // vpsrld ymm13, ymm4, 12
+  db $C5, $DD, $72, $F4, $14                 // vpslld ymm4, ymm4, 20
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+  db $C5, $FD, $FE, $84, $24, $E0, $00, $00, $00 // vpaddd ymm0, ymm0, [rsp+224]
+  db $C5, $FD, $FE, $C4                      // vpaddd ymm0, ymm0, ymm4
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C5, $7E, $7F, $A4, $24, $00, $02, $00, $00 // vmovdqu [rsp+512], ymm12
+  db $C4, $C1, $5D, $EF, $E0                 // vpxor ymm4, ymm4, ymm8
+  db $C5, $95, $72, $D4, $07                 // vpsrld ymm13, ymm4, 7
+  db $C5, $DD, $72, $F4, $19                 // vpslld ymm4, ymm4, 25
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+  // G col (1,5,9,13) m[12],m[9]
+  db $C5, $7E, $6F, $A4, $24, $20, $02, $00, $00 // vmovdqu ymm12, [rsp+544]
+  db $C5, $F5, $FE, $8C, $24, $80, $01, $00, $00 // vpaddd ymm1, ymm1, [rsp+384]
+  db $C5, $F5, $FE, $CD                      // vpaddd ymm1, ymm1, ymm5
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C4, $C1, $55, $EF, $E9                 // vpxor ymm5, ymm5, ymm9
+  db $C5, $95, $72, $D5, $0C                 // vpsrld ymm13, ymm5, 12
+  db $C5, $D5, $72, $F5, $14                 // vpslld ymm5, ymm5, 20
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  db $C5, $F5, $FE, $8C, $24, $20, $01, $00, $00 // vpaddd ymm1, ymm1, [rsp+288]
+  db $C5, $F5, $FE, $CD                      // vpaddd ymm1, ymm1, ymm5
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C5, $7E, $7F, $A4, $24, $20, $02, $00, $00 // vmovdqu [rsp+544], ymm12
+  db $C4, $C1, $55, $EF, $E9                 // vpxor ymm5, ymm5, ymm9
+  db $C5, $95, $72, $D5, $07                 // vpsrld ymm13, ymm5, 7
+  db $C5, $D5, $72, $F5, $19                 // vpslld ymm5, ymm5, 25
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  // G col (2,6,10,14) m[14],m[3]
+  db $C5, $7E, $6F, $A4, $24, $40, $02, $00, $00 // vmovdqu ymm12, [rsp+576]
+  db $C5, $ED, $FE, $94, $24, $C0, $01, $00, $00 // vpaddd ymm2, ymm2, [rsp+448]
+  db $C5, $ED, $FE, $D6                      // vpaddd ymm2, ymm2, ymm6
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C4, $C1, $4D, $EF, $F2                 // vpxor ymm6, ymm6, ymm10
+  db $C5, $95, $72, $D6, $0C                 // vpsrld ymm13, ymm6, 12
+  db $C5, $CD, $72, $F6, $14                 // vpslld ymm6, ymm6, 20
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  db $C5, $ED, $FE, $54, $24, $60            // vpaddd ymm2, ymm2, [rsp+96]
+  db $C5, $ED, $FE, $D6                      // vpaddd ymm2, ymm2, ymm6
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C5, $7E, $7F, $A4, $24, $40, $02, $00, $00 // vmovdqu [rsp+576], ymm12
+  db $C4, $C1, $4D, $EF, $F2                 // vpxor ymm6, ymm6, ymm10
+  db $C5, $95, $72, $D6, $07                 // vpsrld ymm13, ymm6, 7
+  db $C5, $CD, $72, $F6, $19                 // vpslld ymm6, ymm6, 25
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  // G col (3,7,11,15) m[13],m[15]
+  db $C5, $7E, $6F, $A4, $24, $60, $02, $00, $00 // vmovdqu ymm12, [rsp+608]
+  db $C5, $E5, $FE, $9C, $24, $A0, $01, $00, $00 // vpaddd ymm3, ymm3, [rsp+416]
+  db $C5, $E5, $FE, $DF                      // vpaddd ymm3, ymm3, ymm7
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C4, $C1, $45, $EF, $FB                 // vpxor ymm7, ymm7, ymm11
+  db $C5, $95, $72, $D7, $0C                 // vpsrld ymm13, ymm7, 12
+  db $C5, $C5, $72, $F7, $14                 // vpslld ymm7, ymm7, 20
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  db $C5, $E5, $FE, $9C, $24, $E0, $01, $00, $00 // vpaddd ymm3, ymm3, [rsp+480]
+  db $C5, $E5, $FE, $DF                      // vpaddd ymm3, ymm3, ymm7
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C5, $7E, $7F, $A4, $24, $60, $02, $00, $00 // vmovdqu [rsp+608], ymm12
+  db $C4, $C1, $45, $EF, $FB                 // vpxor ymm7, ymm7, ymm11
+  db $C5, $95, $72, $D7, $07                 // vpsrld ymm13, ymm7, 7
+  db $C5, $C5, $72, $F7, $19                 // vpslld ymm7, ymm7, 25
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  // G diag (0,5,10,15) m[4],m[0]
+  db $C5, $7E, $6F, $A4, $24, $60, $02, $00, $00 // vmovdqu ymm12, [rsp+608]
+  db $C5, $FD, $FE, $84, $24, $80, $00, $00, $00 // vpaddd ymm0, ymm0, [rsp+128]
+  db $C5, $FD, $FE, $C5                      // vpaddd ymm0, ymm0, ymm5
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C4, $C1, $55, $EF, $EA                 // vpxor ymm5, ymm5, ymm10
+  db $C5, $95, $72, $D5, $0C                 // vpsrld ymm13, ymm5, 12
+  db $C5, $D5, $72, $F5, $14                 // vpslld ymm5, ymm5, 20
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  db $C5, $FD, $FE, $04, $24                 // vpaddd ymm0, ymm0, [rsp+0]
+  db $C5, $FD, $FE, $C5                      // vpaddd ymm0, ymm0, ymm5
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C5, $7E, $7F, $A4, $24, $60, $02, $00, $00 // vmovdqu [rsp+608], ymm12
+  db $C4, $C1, $55, $EF, $EA                 // vpxor ymm5, ymm5, ymm10
+  db $C5, $95, $72, $D5, $07                 // vpsrld ymm13, ymm5, 7
+  db $C5, $D5, $72, $F5, $19                 // vpslld ymm5, ymm5, 25
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  // G diag (1,6,11,12) m[11],m[2]
+  db $C5, $7E, $6F, $A4, $24, $00, $02, $00, $00 // vmovdqu ymm12, [rsp+512]
+  db $C5, $F5, $FE, $8C, $24, $60, $01, $00, $00 // vpaddd ymm1, ymm1, [rsp+352]
+  db $C5, $F5, $FE, $CE                      // vpaddd ymm1, ymm1, ymm6
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C4, $C1, $4D, $EF, $F3                 // vpxor ymm6, ymm6, ymm11
+  db $C5, $95, $72, $D6, $0C                 // vpsrld ymm13, ymm6, 12
+  db $C5, $CD, $72, $F6, $14                 // vpslld ymm6, ymm6, 20
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  db $C5, $F5, $FE, $4C, $24, $40            // vpaddd ymm1, ymm1, [rsp+64]
+  db $C5, $F5, $FE, $CE                      // vpaddd ymm1, ymm1, ymm6
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C5, $7E, $7F, $A4, $24, $00, $02, $00, $00 // vmovdqu [rsp+512], ymm12
+  db $C4, $C1, $4D, $EF, $F3                 // vpxor ymm6, ymm6, ymm11
+  db $C5, $95, $72, $D6, $07                 // vpsrld ymm13, ymm6, 7
+  db $C5, $CD, $72, $F6, $19                 // vpslld ymm6, ymm6, 25
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  // G diag (2,7,8,13) m[5],m[8]
+  db $C5, $7E, $6F, $A4, $24, $20, $02, $00, $00 // vmovdqu ymm12, [rsp+544]
+  db $C5, $ED, $FE, $94, $24, $A0, $00, $00, $00 // vpaddd ymm2, ymm2, [rsp+160]
+  db $C5, $ED, $FE, $D7                      // vpaddd ymm2, ymm2, ymm7
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C4, $C1, $45, $EF, $F8                 // vpxor ymm7, ymm7, ymm8
+  db $C5, $95, $72, $D7, $0C                 // vpsrld ymm13, ymm7, 12
+  db $C5, $C5, $72, $F7, $14                 // vpslld ymm7, ymm7, 20
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  db $C5, $ED, $FE, $94, $24, $00, $01, $00, $00 // vpaddd ymm2, ymm2, [rsp+256]
+  db $C5, $ED, $FE, $D7                      // vpaddd ymm2, ymm2, ymm7
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C5, $7E, $7F, $A4, $24, $20, $02, $00, $00 // vmovdqu [rsp+544], ymm12
+  db $C4, $C1, $45, $EF, $F8                 // vpxor ymm7, ymm7, ymm8
+  db $C5, $95, $72, $D7, $07                 // vpsrld ymm13, ymm7, 7
+  db $C5, $C5, $72, $F7, $19                 // vpslld ymm7, ymm7, 25
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  // G diag (3,4,9,14) m[1],m[6]
+  db $C5, $7E, $6F, $A4, $24, $40, $02, $00, $00 // vmovdqu ymm12, [rsp+576]
+  db $C5, $E5, $FE, $5C, $24, $20            // vpaddd ymm3, ymm3, [rsp+32]
+  db $C5, $E5, $FE, $DC                      // vpaddd ymm3, ymm3, ymm4
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C4, $C1, $5D, $EF, $E1                 // vpxor ymm4, ymm4, ymm9
+  db $C5, $95, $72, $D4, $0C                 // vpsrld ymm13, ymm4, 12
+  db $C5, $DD, $72, $F4, $14                 // vpslld ymm4, ymm4, 20
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+  db $C5, $E5, $FE, $9C, $24, $C0, $00, $00, $00 // vpaddd ymm3, ymm3, [rsp+192]
+  db $C5, $E5, $FE, $DC                      // vpaddd ymm3, ymm3, ymm4
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C5, $7E, $7F, $A4, $24, $40, $02, $00, $00 // vmovdqu [rsp+576], ymm12
+  db $C4, $C1, $5D, $EF, $E1                 // vpxor ymm4, ymm4, ymm9
+  db $C5, $95, $72, $D4, $07                 // vpsrld ymm13, ymm4, 7
+  db $C5, $DD, $72, $F4, $19                 // vpslld ymm4, ymm4, 25
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+
+  // === Round 4 ===
+  // G col (0,4,8,12) m[12],m[13]
+  db $C5, $7E, $6F, $A4, $24, $00, $02, $00, $00 // vmovdqu ymm12, [rsp+512]
+  db $C5, $FD, $FE, $84, $24, $80, $01, $00, $00 // vpaddd ymm0, ymm0, [rsp+384]
+  db $C5, $FD, $FE, $C4                      // vpaddd ymm0, ymm0, ymm4
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C4, $C1, $5D, $EF, $E0                 // vpxor ymm4, ymm4, ymm8
+  db $C5, $95, $72, $D4, $0C                 // vpsrld ymm13, ymm4, 12
+  db $C5, $DD, $72, $F4, $14                 // vpslld ymm4, ymm4, 20
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+  db $C5, $FD, $FE, $84, $24, $A0, $01, $00, $00 // vpaddd ymm0, ymm0, [rsp+416]
+  db $C5, $FD, $FE, $C4                      // vpaddd ymm0, ymm0, ymm4
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C5, $7E, $7F, $A4, $24, $00, $02, $00, $00 // vmovdqu [rsp+512], ymm12
+  db $C4, $C1, $5D, $EF, $E0                 // vpxor ymm4, ymm4, ymm8
+  db $C5, $95, $72, $D4, $07                 // vpsrld ymm13, ymm4, 7
+  db $C5, $DD, $72, $F4, $19                 // vpslld ymm4, ymm4, 25
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+  // G col (1,5,9,13) m[9],m[11]
+  db $C5, $7E, $6F, $A4, $24, $20, $02, $00, $00 // vmovdqu ymm12, [rsp+544]
+  db $C5, $F5, $FE, $8C, $24, $20, $01, $00, $00 // vpaddd ymm1, ymm1, [rsp+288]
+  db $C5, $F5, $FE, $CD                      // vpaddd ymm1, ymm1, ymm5
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C4, $C1, $55, $EF, $E9                 // vpxor ymm5, ymm5, ymm9
+  db $C5, $95, $72, $D5, $0C                 // vpsrld ymm13, ymm5, 12
+  db $C5, $D5, $72, $F5, $14                 // vpslld ymm5, ymm5, 20
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  db $C5, $F5, $FE, $8C, $24, $60, $01, $00, $00 // vpaddd ymm1, ymm1, [rsp+352]
+  db $C5, $F5, $FE, $CD                      // vpaddd ymm1, ymm1, ymm5
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C5, $7E, $7F, $A4, $24, $20, $02, $00, $00 // vmovdqu [rsp+544], ymm12
+  db $C4, $C1, $55, $EF, $E9                 // vpxor ymm5, ymm5, ymm9
+  db $C5, $95, $72, $D5, $07                 // vpsrld ymm13, ymm5, 7
+  db $C5, $D5, $72, $F5, $19                 // vpslld ymm5, ymm5, 25
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  // G col (2,6,10,14) m[15],m[10]
+  db $C5, $7E, $6F, $A4, $24, $40, $02, $00, $00 // vmovdqu ymm12, [rsp+576]
+  db $C5, $ED, $FE, $94, $24, $E0, $01, $00, $00 // vpaddd ymm2, ymm2, [rsp+480]
+  db $C5, $ED, $FE, $D6                      // vpaddd ymm2, ymm2, ymm6
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C4, $C1, $4D, $EF, $F2                 // vpxor ymm6, ymm6, ymm10
+  db $C5, $95, $72, $D6, $0C                 // vpsrld ymm13, ymm6, 12
+  db $C5, $CD, $72, $F6, $14                 // vpslld ymm6, ymm6, 20
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  db $C5, $ED, $FE, $94, $24, $40, $01, $00, $00 // vpaddd ymm2, ymm2, [rsp+320]
+  db $C5, $ED, $FE, $D6                      // vpaddd ymm2, ymm2, ymm6
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C5, $7E, $7F, $A4, $24, $40, $02, $00, $00 // vmovdqu [rsp+576], ymm12
+  db $C4, $C1, $4D, $EF, $F2                 // vpxor ymm6, ymm6, ymm10
+  db $C5, $95, $72, $D6, $07                 // vpsrld ymm13, ymm6, 7
+  db $C5, $CD, $72, $F6, $19                 // vpslld ymm6, ymm6, 25
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  // G col (3,7,11,15) m[14],m[8]
+  db $C5, $7E, $6F, $A4, $24, $60, $02, $00, $00 // vmovdqu ymm12, [rsp+608]
+  db $C5, $E5, $FE, $9C, $24, $C0, $01, $00, $00 // vpaddd ymm3, ymm3, [rsp+448]
+  db $C5, $E5, $FE, $DF                      // vpaddd ymm3, ymm3, ymm7
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C4, $C1, $45, $EF, $FB                 // vpxor ymm7, ymm7, ymm11
+  db $C5, $95, $72, $D7, $0C                 // vpsrld ymm13, ymm7, 12
+  db $C5, $C5, $72, $F7, $14                 // vpslld ymm7, ymm7, 20
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  db $C5, $E5, $FE, $9C, $24, $00, $01, $00, $00 // vpaddd ymm3, ymm3, [rsp+256]
+  db $C5, $E5, $FE, $DF                      // vpaddd ymm3, ymm3, ymm7
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C5, $7E, $7F, $A4, $24, $60, $02, $00, $00 // vmovdqu [rsp+608], ymm12
+  db $C4, $C1, $45, $EF, $FB                 // vpxor ymm7, ymm7, ymm11
+  db $C5, $95, $72, $D7, $07                 // vpsrld ymm13, ymm7, 7
+  db $C5, $C5, $72, $F7, $19                 // vpslld ymm7, ymm7, 25
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  // G diag (0,5,10,15) m[7],m[2]
+  db $C5, $7E, $6F, $A4, $24, $60, $02, $00, $00 // vmovdqu ymm12, [rsp+608]
+  db $C5, $FD, $FE, $84, $24, $E0, $00, $00, $00 // vpaddd ymm0, ymm0, [rsp+224]
+  db $C5, $FD, $FE, $C5                      // vpaddd ymm0, ymm0, ymm5
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C4, $C1, $55, $EF, $EA                 // vpxor ymm5, ymm5, ymm10
+  db $C5, $95, $72, $D5, $0C                 // vpsrld ymm13, ymm5, 12
+  db $C5, $D5, $72, $F5, $14                 // vpslld ymm5, ymm5, 20
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  db $C5, $FD, $FE, $44, $24, $40            // vpaddd ymm0, ymm0, [rsp+64]
+  db $C5, $FD, $FE, $C5                      // vpaddd ymm0, ymm0, ymm5
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C5, $7E, $7F, $A4, $24, $60, $02, $00, $00 // vmovdqu [rsp+608], ymm12
+  db $C4, $C1, $55, $EF, $EA                 // vpxor ymm5, ymm5, ymm10
+  db $C5, $95, $72, $D5, $07                 // vpsrld ymm13, ymm5, 7
+  db $C5, $D5, $72, $F5, $19                 // vpslld ymm5, ymm5, 25
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  // G diag (1,6,11,12) m[5],m[3]
+  db $C5, $7E, $6F, $A4, $24, $00, $02, $00, $00 // vmovdqu ymm12, [rsp+512]
+  db $C5, $F5, $FE, $8C, $24, $A0, $00, $00, $00 // vpaddd ymm1, ymm1, [rsp+160]
+  db $C5, $F5, $FE, $CE                      // vpaddd ymm1, ymm1, ymm6
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C4, $C1, $4D, $EF, $F3                 // vpxor ymm6, ymm6, ymm11
+  db $C5, $95, $72, $D6, $0C                 // vpsrld ymm13, ymm6, 12
+  db $C5, $CD, $72, $F6, $14                 // vpslld ymm6, ymm6, 20
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  db $C5, $F5, $FE, $4C, $24, $60            // vpaddd ymm1, ymm1, [rsp+96]
+  db $C5, $F5, $FE, $CE                      // vpaddd ymm1, ymm1, ymm6
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C5, $7E, $7F, $A4, $24, $00, $02, $00, $00 // vmovdqu [rsp+512], ymm12
+  db $C4, $C1, $4D, $EF, $F3                 // vpxor ymm6, ymm6, ymm11
+  db $C5, $95, $72, $D6, $07                 // vpsrld ymm13, ymm6, 7
+  db $C5, $CD, $72, $F6, $19                 // vpslld ymm6, ymm6, 25
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  // G diag (2,7,8,13) m[0],m[1]
+  db $C5, $7E, $6F, $A4, $24, $20, $02, $00, $00 // vmovdqu ymm12, [rsp+544]
+  db $C5, $ED, $FE, $14, $24                 // vpaddd ymm2, ymm2, [rsp+0]
+  db $C5, $ED, $FE, $D7                      // vpaddd ymm2, ymm2, ymm7
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C4, $C1, $45, $EF, $F8                 // vpxor ymm7, ymm7, ymm8
+  db $C5, $95, $72, $D7, $0C                 // vpsrld ymm13, ymm7, 12
+  db $C5, $C5, $72, $F7, $14                 // vpslld ymm7, ymm7, 20
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  db $C5, $ED, $FE, $54, $24, $20            // vpaddd ymm2, ymm2, [rsp+32]
+  db $C5, $ED, $FE, $D7                      // vpaddd ymm2, ymm2, ymm7
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C5, $7E, $7F, $A4, $24, $20, $02, $00, $00 // vmovdqu [rsp+544], ymm12
+  db $C4, $C1, $45, $EF, $F8                 // vpxor ymm7, ymm7, ymm8
+  db $C5, $95, $72, $D7, $07                 // vpsrld ymm13, ymm7, 7
+  db $C5, $C5, $72, $F7, $19                 // vpslld ymm7, ymm7, 25
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  // G diag (3,4,9,14) m[6],m[4]
+  db $C5, $7E, $6F, $A4, $24, $40, $02, $00, $00 // vmovdqu ymm12, [rsp+576]
+  db $C5, $E5, $FE, $9C, $24, $C0, $00, $00, $00 // vpaddd ymm3, ymm3, [rsp+192]
+  db $C5, $E5, $FE, $DC                      // vpaddd ymm3, ymm3, ymm4
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C4, $C1, $5D, $EF, $E1                 // vpxor ymm4, ymm4, ymm9
+  db $C5, $95, $72, $D4, $0C                 // vpsrld ymm13, ymm4, 12
+  db $C5, $DD, $72, $F4, $14                 // vpslld ymm4, ymm4, 20
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+  db $C5, $E5, $FE, $9C, $24, $80, $00, $00, $00 // vpaddd ymm3, ymm3, [rsp+128]
+  db $C5, $E5, $FE, $DC                      // vpaddd ymm3, ymm3, ymm4
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C5, $7E, $7F, $A4, $24, $40, $02, $00, $00 // vmovdqu [rsp+576], ymm12
+  db $C4, $C1, $5D, $EF, $E1                 // vpxor ymm4, ymm4, ymm9
+  db $C5, $95, $72, $D4, $07                 // vpsrld ymm13, ymm4, 7
+  db $C5, $DD, $72, $F4, $19                 // vpslld ymm4, ymm4, 25
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+
+  // === Round 5 ===
+  // G col (0,4,8,12) m[9],m[14]
+  db $C5, $7E, $6F, $A4, $24, $00, $02, $00, $00 // vmovdqu ymm12, [rsp+512]
+  db $C5, $FD, $FE, $84, $24, $20, $01, $00, $00 // vpaddd ymm0, ymm0, [rsp+288]
+  db $C5, $FD, $FE, $C4                      // vpaddd ymm0, ymm0, ymm4
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C4, $C1, $5D, $EF, $E0                 // vpxor ymm4, ymm4, ymm8
+  db $C5, $95, $72, $D4, $0C                 // vpsrld ymm13, ymm4, 12
+  db $C5, $DD, $72, $F4, $14                 // vpslld ymm4, ymm4, 20
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+  db $C5, $FD, $FE, $84, $24, $C0, $01, $00, $00 // vpaddd ymm0, ymm0, [rsp+448]
+  db $C5, $FD, $FE, $C4                      // vpaddd ymm0, ymm0, ymm4
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C5, $7E, $7F, $A4, $24, $00, $02, $00, $00 // vmovdqu [rsp+512], ymm12
+  db $C4, $C1, $5D, $EF, $E0                 // vpxor ymm4, ymm4, ymm8
+  db $C5, $95, $72, $D4, $07                 // vpsrld ymm13, ymm4, 7
+  db $C5, $DD, $72, $F4, $19                 // vpslld ymm4, ymm4, 25
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+  // G col (1,5,9,13) m[11],m[5]
+  db $C5, $7E, $6F, $A4, $24, $20, $02, $00, $00 // vmovdqu ymm12, [rsp+544]
+  db $C5, $F5, $FE, $8C, $24, $60, $01, $00, $00 // vpaddd ymm1, ymm1, [rsp+352]
+  db $C5, $F5, $FE, $CD                      // vpaddd ymm1, ymm1, ymm5
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C4, $C1, $55, $EF, $E9                 // vpxor ymm5, ymm5, ymm9
+  db $C5, $95, $72, $D5, $0C                 // vpsrld ymm13, ymm5, 12
+  db $C5, $D5, $72, $F5, $14                 // vpslld ymm5, ymm5, 20
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  db $C5, $F5, $FE, $8C, $24, $A0, $00, $00, $00 // vpaddd ymm1, ymm1, [rsp+160]
+  db $C5, $F5, $FE, $CD                      // vpaddd ymm1, ymm1, ymm5
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C5, $7E, $7F, $A4, $24, $20, $02, $00, $00 // vmovdqu [rsp+544], ymm12
+  db $C4, $C1, $55, $EF, $E9                 // vpxor ymm5, ymm5, ymm9
+  db $C5, $95, $72, $D5, $07                 // vpsrld ymm13, ymm5, 7
+  db $C5, $D5, $72, $F5, $19                 // vpslld ymm5, ymm5, 25
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  // G col (2,6,10,14) m[8],m[12]
+  db $C5, $7E, $6F, $A4, $24, $40, $02, $00, $00 // vmovdqu ymm12, [rsp+576]
+  db $C5, $ED, $FE, $94, $24, $00, $01, $00, $00 // vpaddd ymm2, ymm2, [rsp+256]
+  db $C5, $ED, $FE, $D6                      // vpaddd ymm2, ymm2, ymm6
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C4, $C1, $4D, $EF, $F2                 // vpxor ymm6, ymm6, ymm10
+  db $C5, $95, $72, $D6, $0C                 // vpsrld ymm13, ymm6, 12
+  db $C5, $CD, $72, $F6, $14                 // vpslld ymm6, ymm6, 20
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  db $C5, $ED, $FE, $94, $24, $80, $01, $00, $00 // vpaddd ymm2, ymm2, [rsp+384]
+  db $C5, $ED, $FE, $D6                      // vpaddd ymm2, ymm2, ymm6
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C5, $7E, $7F, $A4, $24, $40, $02, $00, $00 // vmovdqu [rsp+576], ymm12
+  db $C4, $C1, $4D, $EF, $F2                 // vpxor ymm6, ymm6, ymm10
+  db $C5, $95, $72, $D6, $07                 // vpsrld ymm13, ymm6, 7
+  db $C5, $CD, $72, $F6, $19                 // vpslld ymm6, ymm6, 25
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  // G col (3,7,11,15) m[15],m[1]
+  db $C5, $7E, $6F, $A4, $24, $60, $02, $00, $00 // vmovdqu ymm12, [rsp+608]
+  db $C5, $E5, $FE, $9C, $24, $E0, $01, $00, $00 // vpaddd ymm3, ymm3, [rsp+480]
+  db $C5, $E5, $FE, $DF                      // vpaddd ymm3, ymm3, ymm7
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C4, $C1, $45, $EF, $FB                 // vpxor ymm7, ymm7, ymm11
+  db $C5, $95, $72, $D7, $0C                 // vpsrld ymm13, ymm7, 12
+  db $C5, $C5, $72, $F7, $14                 // vpslld ymm7, ymm7, 20
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  db $C5, $E5, $FE, $5C, $24, $20            // vpaddd ymm3, ymm3, [rsp+32]
+  db $C5, $E5, $FE, $DF                      // vpaddd ymm3, ymm3, ymm7
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C5, $7E, $7F, $A4, $24, $60, $02, $00, $00 // vmovdqu [rsp+608], ymm12
+  db $C4, $C1, $45, $EF, $FB                 // vpxor ymm7, ymm7, ymm11
+  db $C5, $95, $72, $D7, $07                 // vpsrld ymm13, ymm7, 7
+  db $C5, $C5, $72, $F7, $19                 // vpslld ymm7, ymm7, 25
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  // G diag (0,5,10,15) m[13],m[3]
+  db $C5, $7E, $6F, $A4, $24, $60, $02, $00, $00 // vmovdqu ymm12, [rsp+608]
+  db $C5, $FD, $FE, $84, $24, $A0, $01, $00, $00 // vpaddd ymm0, ymm0, [rsp+416]
+  db $C5, $FD, $FE, $C5                      // vpaddd ymm0, ymm0, ymm5
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C4, $C1, $55, $EF, $EA                 // vpxor ymm5, ymm5, ymm10
+  db $C5, $95, $72, $D5, $0C                 // vpsrld ymm13, ymm5, 12
+  db $C5, $D5, $72, $F5, $14                 // vpslld ymm5, ymm5, 20
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  db $C5, $FD, $FE, $44, $24, $60            // vpaddd ymm0, ymm0, [rsp+96]
+  db $C5, $FD, $FE, $C5                      // vpaddd ymm0, ymm0, ymm5
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C5, $7E, $7F, $A4, $24, $60, $02, $00, $00 // vmovdqu [rsp+608], ymm12
+  db $C4, $C1, $55, $EF, $EA                 // vpxor ymm5, ymm5, ymm10
+  db $C5, $95, $72, $D5, $07                 // vpsrld ymm13, ymm5, 7
+  db $C5, $D5, $72, $F5, $19                 // vpslld ymm5, ymm5, 25
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  // G diag (1,6,11,12) m[0],m[10]
+  db $C5, $7E, $6F, $A4, $24, $00, $02, $00, $00 // vmovdqu ymm12, [rsp+512]
+  db $C5, $F5, $FE, $0C, $24                 // vpaddd ymm1, ymm1, [rsp+0]
+  db $C5, $F5, $FE, $CE                      // vpaddd ymm1, ymm1, ymm6
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C4, $C1, $4D, $EF, $F3                 // vpxor ymm6, ymm6, ymm11
+  db $C5, $95, $72, $D6, $0C                 // vpsrld ymm13, ymm6, 12
+  db $C5, $CD, $72, $F6, $14                 // vpslld ymm6, ymm6, 20
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  db $C5, $F5, $FE, $8C, $24, $40, $01, $00, $00 // vpaddd ymm1, ymm1, [rsp+320]
+  db $C5, $F5, $FE, $CE                      // vpaddd ymm1, ymm1, ymm6
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C5, $7E, $7F, $A4, $24, $00, $02, $00, $00 // vmovdqu [rsp+512], ymm12
+  db $C4, $C1, $4D, $EF, $F3                 // vpxor ymm6, ymm6, ymm11
+  db $C5, $95, $72, $D6, $07                 // vpsrld ymm13, ymm6, 7
+  db $C5, $CD, $72, $F6, $19                 // vpslld ymm6, ymm6, 25
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  // G diag (2,7,8,13) m[2],m[6]
+  db $C5, $7E, $6F, $A4, $24, $20, $02, $00, $00 // vmovdqu ymm12, [rsp+544]
+  db $C5, $ED, $FE, $54, $24, $40            // vpaddd ymm2, ymm2, [rsp+64]
+  db $C5, $ED, $FE, $D7                      // vpaddd ymm2, ymm2, ymm7
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C4, $C1, $45, $EF, $F8                 // vpxor ymm7, ymm7, ymm8
+  db $C5, $95, $72, $D7, $0C                 // vpsrld ymm13, ymm7, 12
+  db $C5, $C5, $72, $F7, $14                 // vpslld ymm7, ymm7, 20
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  db $C5, $ED, $FE, $94, $24, $C0, $00, $00, $00 // vpaddd ymm2, ymm2, [rsp+192]
+  db $C5, $ED, $FE, $D7                      // vpaddd ymm2, ymm2, ymm7
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C5, $7E, $7F, $A4, $24, $20, $02, $00, $00 // vmovdqu [rsp+544], ymm12
+  db $C4, $C1, $45, $EF, $F8                 // vpxor ymm7, ymm7, ymm8
+  db $C5, $95, $72, $D7, $07                 // vpsrld ymm13, ymm7, 7
+  db $C5, $C5, $72, $F7, $19                 // vpslld ymm7, ymm7, 25
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  // G diag (3,4,9,14) m[4],m[7]
+  db $C5, $7E, $6F, $A4, $24, $40, $02, $00, $00 // vmovdqu ymm12, [rsp+576]
+  db $C5, $E5, $FE, $9C, $24, $80, $00, $00, $00 // vpaddd ymm3, ymm3, [rsp+128]
+  db $C5, $E5, $FE, $DC                      // vpaddd ymm3, ymm3, ymm4
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C4, $C1, $5D, $EF, $E1                 // vpxor ymm4, ymm4, ymm9
+  db $C5, $95, $72, $D4, $0C                 // vpsrld ymm13, ymm4, 12
+  db $C5, $DD, $72, $F4, $14                 // vpslld ymm4, ymm4, 20
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+  db $C5, $E5, $FE, $9C, $24, $E0, $00, $00, $00 // vpaddd ymm3, ymm3, [rsp+224]
+  db $C5, $E5, $FE, $DC                      // vpaddd ymm3, ymm3, ymm4
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C5, $7E, $7F, $A4, $24, $40, $02, $00, $00 // vmovdqu [rsp+576], ymm12
+  db $C4, $C1, $5D, $EF, $E1                 // vpxor ymm4, ymm4, ymm9
+  db $C5, $95, $72, $D4, $07                 // vpsrld ymm13, ymm4, 7
+  db $C5, $DD, $72, $F4, $19                 // vpslld ymm4, ymm4, 25
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+
+  // === Round 6 ===
+  // G col (0,4,8,12) m[11],m[15]
+  db $C5, $7E, $6F, $A4, $24, $00, $02, $00, $00 // vmovdqu ymm12, [rsp+512]
+  db $C5, $FD, $FE, $84, $24, $60, $01, $00, $00 // vpaddd ymm0, ymm0, [rsp+352]
+  db $C5, $FD, $FE, $C4                      // vpaddd ymm0, ymm0, ymm4
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C4, $C1, $5D, $EF, $E0                 // vpxor ymm4, ymm4, ymm8
+  db $C5, $95, $72, $D4, $0C                 // vpsrld ymm13, ymm4, 12
+  db $C5, $DD, $72, $F4, $14                 // vpslld ymm4, ymm4, 20
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+  db $C5, $FD, $FE, $84, $24, $E0, $01, $00, $00 // vpaddd ymm0, ymm0, [rsp+480]
+  db $C5, $FD, $FE, $C4                      // vpaddd ymm0, ymm0, ymm4
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C5, $7E, $7F, $A4, $24, $00, $02, $00, $00 // vmovdqu [rsp+512], ymm12
+  db $C4, $C1, $5D, $EF, $E0                 // vpxor ymm4, ymm4, ymm8
+  db $C5, $95, $72, $D4, $07                 // vpsrld ymm13, ymm4, 7
+  db $C5, $DD, $72, $F4, $19                 // vpslld ymm4, ymm4, 25
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+  // G col (1,5,9,13) m[5],m[0]
+  db $C5, $7E, $6F, $A4, $24, $20, $02, $00, $00 // vmovdqu ymm12, [rsp+544]
+  db $C5, $F5, $FE, $8C, $24, $A0, $00, $00, $00 // vpaddd ymm1, ymm1, [rsp+160]
+  db $C5, $F5, $FE, $CD                      // vpaddd ymm1, ymm1, ymm5
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C4, $C1, $55, $EF, $E9                 // vpxor ymm5, ymm5, ymm9
+  db $C5, $95, $72, $D5, $0C                 // vpsrld ymm13, ymm5, 12
+  db $C5, $D5, $72, $F5, $14                 // vpslld ymm5, ymm5, 20
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  db $C5, $F5, $FE, $0C, $24                 // vpaddd ymm1, ymm1, [rsp+0]
+  db $C5, $F5, $FE, $CD                      // vpaddd ymm1, ymm1, ymm5
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C5, $7E, $7F, $A4, $24, $20, $02, $00, $00 // vmovdqu [rsp+544], ymm12
+  db $C4, $C1, $55, $EF, $E9                 // vpxor ymm5, ymm5, ymm9
+  db $C5, $95, $72, $D5, $07                 // vpsrld ymm13, ymm5, 7
+  db $C5, $D5, $72, $F5, $19                 // vpslld ymm5, ymm5, 25
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  // G col (2,6,10,14) m[1],m[9]
+  db $C5, $7E, $6F, $A4, $24, $40, $02, $00, $00 // vmovdqu ymm12, [rsp+576]
+  db $C5, $ED, $FE, $54, $24, $20            // vpaddd ymm2, ymm2, [rsp+32]
+  db $C5, $ED, $FE, $D6                      // vpaddd ymm2, ymm2, ymm6
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C4, $C1, $4D, $EF, $F2                 // vpxor ymm6, ymm6, ymm10
+  db $C5, $95, $72, $D6, $0C                 // vpsrld ymm13, ymm6, 12
+  db $C5, $CD, $72, $F6, $14                 // vpslld ymm6, ymm6, 20
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  db $C5, $ED, $FE, $94, $24, $20, $01, $00, $00 // vpaddd ymm2, ymm2, [rsp+288]
+  db $C5, $ED, $FE, $D6                      // vpaddd ymm2, ymm2, ymm6
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C5, $7E, $7F, $A4, $24, $40, $02, $00, $00 // vmovdqu [rsp+576], ymm12
+  db $C4, $C1, $4D, $EF, $F2                 // vpxor ymm6, ymm6, ymm10
+  db $C5, $95, $72, $D6, $07                 // vpsrld ymm13, ymm6, 7
+  db $C5, $CD, $72, $F6, $19                 // vpslld ymm6, ymm6, 25
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  // G col (3,7,11,15) m[8],m[6]
+  db $C5, $7E, $6F, $A4, $24, $60, $02, $00, $00 // vmovdqu ymm12, [rsp+608]
+  db $C5, $E5, $FE, $9C, $24, $00, $01, $00, $00 // vpaddd ymm3, ymm3, [rsp+256]
+  db $C5, $E5, $FE, $DF                      // vpaddd ymm3, ymm3, ymm7
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C4, $C1, $45, $EF, $FB                 // vpxor ymm7, ymm7, ymm11
+  db $C5, $95, $72, $D7, $0C                 // vpsrld ymm13, ymm7, 12
+  db $C5, $C5, $72, $F7, $14                 // vpslld ymm7, ymm7, 20
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  db $C5, $E5, $FE, $9C, $24, $C0, $00, $00, $00 // vpaddd ymm3, ymm3, [rsp+192]
+  db $C5, $E5, $FE, $DF                      // vpaddd ymm3, ymm3, ymm7
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C5, $7E, $7F, $A4, $24, $60, $02, $00, $00 // vmovdqu [rsp+608], ymm12
+  db $C4, $C1, $45, $EF, $FB                 // vpxor ymm7, ymm7, ymm11
+  db $C5, $95, $72, $D7, $07                 // vpsrld ymm13, ymm7, 7
+  db $C5, $C5, $72, $F7, $19                 // vpslld ymm7, ymm7, 25
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  // G diag (0,5,10,15) m[14],m[10]
+  db $C5, $7E, $6F, $A4, $24, $60, $02, $00, $00 // vmovdqu ymm12, [rsp+608]
+  db $C5, $FD, $FE, $84, $24, $C0, $01, $00, $00 // vpaddd ymm0, ymm0, [rsp+448]
+  db $C5, $FD, $FE, $C5                      // vpaddd ymm0, ymm0, ymm5
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C4, $C1, $55, $EF, $EA                 // vpxor ymm5, ymm5, ymm10
+  db $C5, $95, $72, $D5, $0C                 // vpsrld ymm13, ymm5, 12
+  db $C5, $D5, $72, $F5, $14                 // vpslld ymm5, ymm5, 20
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  db $C5, $FD, $FE, $84, $24, $40, $01, $00, $00 // vpaddd ymm0, ymm0, [rsp+320]
+  db $C5, $FD, $FE, $C5                      // vpaddd ymm0, ymm0, ymm5
+  db $C5, $1D, $EF, $E0                      // vpxor ymm12, ymm12, ymm0
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $2D, $FE, $D4                 // vpaddd ymm10, ymm10, ymm12
+  db $C5, $7E, $7F, $A4, $24, $60, $02, $00, $00 // vmovdqu [rsp+608], ymm12
+  db $C4, $C1, $55, $EF, $EA                 // vpxor ymm5, ymm5, ymm10
+  db $C5, $95, $72, $D5, $07                 // vpsrld ymm13, ymm5, 7
+  db $C5, $D5, $72, $F5, $19                 // vpslld ymm5, ymm5, 25
+  db $C4, $C1, $55, $EB, $ED                 // vpor ymm5, ymm5, ymm13
+  // G diag (1,6,11,12) m[2],m[12]
+  db $C5, $7E, $6F, $A4, $24, $00, $02, $00, $00 // vmovdqu ymm12, [rsp+512]
+  db $C5, $F5, $FE, $4C, $24, $40            // vpaddd ymm1, ymm1, [rsp+64]
+  db $C5, $F5, $FE, $CE                      // vpaddd ymm1, ymm1, ymm6
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C4, $C1, $4D, $EF, $F3                 // vpxor ymm6, ymm6, ymm11
+  db $C5, $95, $72, $D6, $0C                 // vpsrld ymm13, ymm6, 12
+  db $C5, $CD, $72, $F6, $14                 // vpslld ymm6, ymm6, 20
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  db $C5, $F5, $FE, $8C, $24, $80, $01, $00, $00 // vpaddd ymm1, ymm1, [rsp+384]
+  db $C5, $F5, $FE, $CE                      // vpaddd ymm1, ymm1, ymm6
+  db $C5, $1D, $EF, $E1                      // vpxor ymm12, ymm12, ymm1
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $25, $FE, $DC                 // vpaddd ymm11, ymm11, ymm12
+  db $C5, $7E, $7F, $A4, $24, $00, $02, $00, $00 // vmovdqu [rsp+512], ymm12
+  db $C4, $C1, $4D, $EF, $F3                 // vpxor ymm6, ymm6, ymm11
+  db $C5, $95, $72, $D6, $07                 // vpsrld ymm13, ymm6, 7
+  db $C5, $CD, $72, $F6, $19                 // vpslld ymm6, ymm6, 25
+  db $C4, $C1, $4D, $EB, $F5                 // vpor ymm6, ymm6, ymm13
+  // G diag (2,7,8,13) m[3],m[4]
+  db $C5, $7E, $6F, $A4, $24, $20, $02, $00, $00 // vmovdqu ymm12, [rsp+544]
+  db $C5, $ED, $FE, $54, $24, $60            // vpaddd ymm2, ymm2, [rsp+96]
+  db $C5, $ED, $FE, $D7                      // vpaddd ymm2, ymm2, ymm7
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C4, $C1, $45, $EF, $F8                 // vpxor ymm7, ymm7, ymm8
+  db $C5, $95, $72, $D7, $0C                 // vpsrld ymm13, ymm7, 12
+  db $C5, $C5, $72, $F7, $14                 // vpslld ymm7, ymm7, 20
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  db $C5, $ED, $FE, $94, $24, $80, $00, $00, $00 // vpaddd ymm2, ymm2, [rsp+128]
+  db $C5, $ED, $FE, $D7                      // vpaddd ymm2, ymm2, ymm7
+  db $C5, $1D, $EF, $E2                      // vpxor ymm12, ymm12, ymm2
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $3D, $FE, $C4                 // vpaddd ymm8, ymm8, ymm12
+  db $C5, $7E, $7F, $A4, $24, $20, $02, $00, $00 // vmovdqu [rsp+544], ymm12
+  db $C4, $C1, $45, $EF, $F8                 // vpxor ymm7, ymm7, ymm8
+  db $C5, $95, $72, $D7, $07                 // vpsrld ymm13, ymm7, 7
+  db $C5, $C5, $72, $F7, $19                 // vpslld ymm7, ymm7, 25
+  db $C4, $C1, $45, $EB, $FD                 // vpor ymm7, ymm7, ymm13
+  // G diag (3,4,9,14) m[7],m[13]
+  db $C5, $7E, $6F, $A4, $24, $40, $02, $00, $00 // vmovdqu ymm12, [rsp+576]
+  db $C5, $E5, $FE, $9C, $24, $E0, $00, $00, $00 // vpaddd ymm3, ymm3, [rsp+224]
+  db $C5, $E5, $FE, $DC                      // vpaddd ymm3, ymm3, ymm4
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $41, $7F, $70, $E4, $B1            // vpshuflw ymm12, ymm12, $B1
+  db $C4, $41, $7E, $70, $E4, $B1            // vpshufhw ymm12, ymm12, $B1
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C4, $C1, $5D, $EF, $E1                 // vpxor ymm4, ymm4, ymm9
+  db $C5, $95, $72, $D4, $0C                 // vpsrld ymm13, ymm4, 12
+  db $C5, $DD, $72, $F4, $14                 // vpslld ymm4, ymm4, 20
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+  db $C5, $E5, $FE, $9C, $24, $A0, $01, $00, $00 // vpaddd ymm3, ymm3, [rsp+416]
+  db $C5, $E5, $FE, $DC                      // vpaddd ymm3, ymm3, ymm4
+  db $C5, $1D, $EF, $E3                      // vpxor ymm12, ymm12, ymm3
+  db $C4, $C1, $15, $72, $D4, $08            // vpsrld ymm13, ymm12, 8
+  db $C4, $C1, $1D, $72, $F4, $18            // vpslld ymm12, ymm12, 24
+  db $C4, $41, $1D, $EB, $E5                 // vpor ymm12, ymm12, ymm13
+  db $C4, $41, $35, $FE, $CC                 // vpaddd ymm9, ymm9, ymm12
+  db $C5, $7E, $7F, $A4, $24, $40, $02, $00, $00 // vmovdqu [rsp+576], ymm12
+  db $C4, $C1, $5D, $EF, $E1                 // vpxor ymm4, ymm4, ymm9
+  db $C5, $95, $72, $D4, $07                 // vpsrld ymm13, ymm4, 7
+  db $C5, $DD, $72, $F4, $19                 // vpslld ymm4, ymm4, 25
+  db $C4, $C1, $5D, $EB, $E5                 // vpor ymm4, ymm4, ymm13
+
+  // Finalize: new_cv[i] = v[i] XOR v[i+8]
+  db $C4, $C1, $7D, $EF, $C0                 // vpxor ymm0, ymm0, ymm8
+  db $C4, $C1, $75, $EF, $C9                 // vpxor ymm1, ymm1, ymm9
+  db $C4, $C1, $6D, $EF, $D2                 // vpxor ymm2, ymm2, ymm10
+  db $C4, $C1, $65, $EF, $DB                 // vpxor ymm3, ymm3, ymm11
+  db $C5, $7E, $6F, $A4, $24, $00, $02, $00, $00 // vmovdqu ymm12, [rsp+512]
+  db $C4, $C1, $5D, $EF, $E4                 // vpxor ymm4, ymm4, ymm12
+  db $C5, $7E, $6F, $A4, $24, $20, $02, $00, $00 // vmovdqu ymm12, [rsp+544]
+  db $C4, $C1, $55, $EF, $EC                 // vpxor ymm5, ymm5, ymm12
+  db $C5, $7E, $6F, $A4, $24, $40, $02, $00, $00 // vmovdqu ymm12, [rsp+576]
+  db $C4, $C1, $4D, $EF, $F4                 // vpxor ymm6, ymm6, ymm12
+  db $C5, $7E, $6F, $A4, $24, $60, $02, $00, $00 // vmovdqu ymm12, [rsp+608]
+  db $C4, $C1, $45, $EF, $FC                 // vpxor ymm7, ymm7, ymm12
+
+  // Store new CV
+  db $C5, $FE, $7F, $84, $24, $80, $02, $00, $00 // vmovdqu [rsp+640], ymm0
+  db $C5, $FE, $7F, $8C, $24, $A0, $02, $00, $00 // vmovdqu [rsp+672], ymm1
+  db $C5, $FE, $7F, $94, $24, $C0, $02, $00, $00 // vmovdqu [rsp+704], ymm2
+  db $C5, $FE, $7F, $9C, $24, $E0, $02, $00, $00 // vmovdqu [rsp+736], ymm3
+  db $C5, $FE, $7F, $A4, $24, $00, $03, $00, $00 // vmovdqu [rsp+768], ymm4
+  db $C5, $FE, $7F, $AC, $24, $20, $03, $00, $00 // vmovdqu [rsp+800], ymm5
+  db $C5, $FE, $7F, $B4, $24, $40, $03, $00, $00 // vmovdqu [rsp+832], ymm6
+  db $C5, $FE, $7F, $BC, $24, $60, $03, $00, $00 // vmovdqu [rsp+864], ymm7
+
+  add ebp, 64
+  inc ebx
+  cmp ebx, 16
+  jb @block_loop
+
+  // Output: 8x8 transpose CV back to per-chunk layout
+  mov rax, qword ptr [rsp + 1120]
+
+  db $C5, $FE, $6F, $84, $24, $80, $02, $00, $00 // vmovdqu ymm0, [rsp+640]
+  db $C5, $FE, $6F, $8C, $24, $A0, $02, $00, $00 // vmovdqu ymm1, [rsp+672]
+  db $C5, $FE, $6F, $94, $24, $C0, $02, $00, $00 // vmovdqu ymm2, [rsp+704]
+  db $C5, $FE, $6F, $9C, $24, $E0, $02, $00, $00 // vmovdqu ymm3, [rsp+736]
+  db $C5, $FE, $6F, $A4, $24, $00, $03, $00, $00 // vmovdqu ymm4, [rsp+768]
+  db $C5, $FE, $6F, $AC, $24, $20, $03, $00, $00 // vmovdqu ymm5, [rsp+800]
+  db $C5, $FE, $6F, $B4, $24, $40, $03, $00, $00 // vmovdqu ymm6, [rsp+832]
+  db $C5, $FE, $6F, $BC, $24, $60, $03, $00, $00 // vmovdqu ymm7, [rsp+864]
+  db $C5, $7D, $62, $C1                      // vpunpckldq ymm8, ymm0, ymm1
+  db $C5, $7D, $6A, $C9                      // vpunpckhdq ymm9, ymm0, ymm1
+  db $C5, $6D, $62, $D3                      // vpunpckldq ymm10, ymm2, ymm3
+  db $C5, $6D, $6A, $DB                      // vpunpckhdq ymm11, ymm2, ymm3
+  db $C5, $5D, $62, $E5                      // vpunpckldq ymm12, ymm4, ymm5
+  db $C5, $5D, $6A, $ED                      // vpunpckhdq ymm13, ymm4, ymm5
+  db $C5, $CD, $62, $C7                      // vpunpckldq ymm0, ymm6, ymm7
+  db $C5, $CD, $6A, $CF                      // vpunpckhdq ymm1, ymm6, ymm7
+  db $C4, $C1, $3D, $6C, $D2                 // vpunpcklqdq ymm2, ymm8, ymm10
+  db $C4, $C1, $3D, $6D, $DA                 // vpunpckhqdq ymm3, ymm8, ymm10
+  db $C4, $C1, $35, $6C, $E3                 // vpunpcklqdq ymm4, ymm9, ymm11
+  db $C4, $C1, $35, $6D, $EB                 // vpunpckhqdq ymm5, ymm9, ymm11
+  db $C5, $9D, $6C, $F0                      // vpunpcklqdq ymm6, ymm12, ymm0
+  db $C5, $9D, $6D, $F8                      // vpunpckhqdq ymm7, ymm12, ymm0
+  db $C5, $15, $6C, $C1                      // vpunpcklqdq ymm8, ymm13, ymm1
+  db $C5, $15, $6D, $C9                      // vpunpckhqdq ymm9, ymm13, ymm1
+  db $C4, $E3, $6D, $46, $C6, $20            // vperm2i128 ymm0, ymm2, ymm6, $20
+  db $C4, $63, $6D, $46, $D6, $31            // vperm2i128 ymm10, ymm2, ymm6, $31
+  db $C4, $E3, $65, $46, $CF, $20            // vperm2i128 ymm1, ymm3, ymm7, $20
+  db $C4, $63, $65, $46, $DF, $31            // vperm2i128 ymm11, ymm3, ymm7, $31
+  db $C4, $C3, $5D, $46, $D0, $20            // vperm2i128 ymm2, ymm4, ymm8, $20
+  db $C4, $43, $5D, $46, $E0, $31            // vperm2i128 ymm12, ymm4, ymm8, $31
+  db $C4, $C3, $55, $46, $D9, $20            // vperm2i128 ymm3, ymm5, ymm9, $20
+  db $C4, $43, $55, $46, $E9, $31            // vperm2i128 ymm13, ymm5, ymm9, $31
+  db $C5, $FE, $7F, $00                      // vmovdqu [rax+0], ymm0
+  db $C5, $FE, $7F, $48, $20                 // vmovdqu [rax+32], ymm1
+  db $C5, $FE, $7F, $50, $40                 // vmovdqu [rax+64], ymm2
+  db $C5, $FE, $7F, $58, $60                 // vmovdqu [rax+96], ymm3
+  db $C5, $7E, $7F, $90, $80, $00, $00, $00  // vmovdqu [rax+128], ymm10
+  db $C5, $7E, $7F, $98, $A0, $00, $00, $00  // vmovdqu [rax+160], ymm11
+  db $C5, $7E, $7F, $A0, $C0, $00, $00, $00  // vmovdqu [rax+192], ymm12
+  db $C5, $7E, $7F, $A8, $E0, $00, $00, $00  // vmovdqu [rax+224], ymm13
+
+{$IFDEF MSWINDOWS}
+  db $C5, $FA, $6F, $B4, $24, $80, $04, $00, $00 // vmovdqu xmm6, [rsp+1152]
+  db $C5, $FA, $6F, $BC, $24, $90, $04, $00, $00 // vmovdqu xmm7, [rsp+1168]
+  db $C5, $7A, $6F, $84, $24, $A0, $04, $00, $00 // vmovdqu xmm8, [rsp+1184]
+  db $C5, $7A, $6F, $8C, $24, $B0, $04, $00, $00 // vmovdqu xmm9, [rsp+1200]
+  db $C5, $7A, $6F, $94, $24, $C0, $04, $00, $00 // vmovdqu xmm10, [rsp+1216]
+  db $C5, $7A, $6F, $9C, $24, $D0, $04, $00, $00 // vmovdqu xmm11, [rsp+1232]
+  db $C5, $7A, $6F, $A4, $24, $E0, $04, $00, $00 // vmovdqu xmm12, [rsp+1248]
+  db $C5, $7A, $6F, $AC, $24, $F0, $04, $00, $00 // vmovdqu xmm13, [rsp+1264]
+{$ENDIF}
+
+  db $C5, $F8, $77                           // vzeroupper
+
+  mov rsp, qword ptr [rsp + 1136]
+  pop r12
+  pop rbp
+  pop rbx

--- a/HashLib/src/Include/Simd/Common/SimdProc6Begin.inc
+++ b/HashLib/src/Include/Simd/Common/SimdProc6Begin.inc
@@ -1,0 +1,31 @@
+// Shared SIMD procedure prologue for 6-parameter assembly functions.
+// After inclusion: rcx = param1, rdx = param2, r8 = param3, r9 = param4,
+//   r10 = param5, r11 = param6 (MS x64 ABI layout).
+// On FPC non-Windows (System V ABI), remaps rdi,rsi,rdx,rcx,r8,r9 ->
+//   rcx,rdx,r8,r9,r10,r11. Move order avoids register clobbering.
+// On MS x64, param5/6 are loaded from [rsp+40]/[rsp+48] (after shadow space).
+// Usage:
+//   procedure MyProc(P1, P2, P3: Pointer; P4: Int32; P5: UInt64; P6: UInt32);
+//     {$I SimdProc6Begin.inc}
+//     // ... SIMD instructions using rcx, rdx, r8, r9, r10, r11 ...
+//   end;
+{$IFDEF FPC}
+  assembler; nostackframe;
+ asm
+  {$IFNDEF MSWINDOWS}
+  mov r11, r9
+  mov r10, r8
+  mov r9, rcx
+  mov r8, rdx
+  mov rdx, rsi
+  mov rcx, rdi
+  {$ELSE}
+  mov r10, [rsp + 40]
+  mov r11, [rsp + 48]
+  {$ENDIF}
+{$ELSE}
+ asm
+  .noframe
+  mov r10, [rsp + 40]
+  mov r11, [rsp + 48]
+{$ENDIF}


### PR DESCRIPTION
- Unroll rounds in Blake3_Compress_Scalar loop
- Inline G
- Reduce heap allocations by using stack-allocated arrays
- Add cascade wrapper procedures (Blake3_HashMany_Avx2, Blake3_HashMany_Sse2) matching the official BLAKE3 C reference dispatch pattern: AVX2 hash8 → SSE2 hash4 → scalar hash_one
- Update TransformBytes to pass variable chunk counts to HashMany instead of fixed ParallelDegree-sized batches, allowing the cascade to process any remainder (e.g. 5 leftover chunks → hash4 + 1 scalar)