### PR TITLE
fix: scalar-first SIMD dispatch fallback across all dispatchers

### DIFF
--- a/HashLib/src/Checksum/HlpAdler32Dispatch.pas
+++ b/HashLib/src/Checksum/HlpAdler32Dispatch.pas
@@ -153,8 +153,9 @@ end;
 
 procedure InitDispatch();
 begin
-  case TSimd.GetActiveLevel() of
+  Adler32_Update := @Adler32_Update_Scalar;
 {$IFDEF HASHLIB_X86_64}
+  case TSimd.GetActiveLevel() of
     TSimdLevel.AVX2:
     begin
       Adler32_Update := @Adler32_Update_Avx2;
@@ -167,12 +168,8 @@ begin
     begin
       Adler32_Update := @Adler32_Update_Sse2;
     end;
-{$ENDIF}
-    TSimdLevel.Scalar:
-    begin
-      Adler32_Update := @Adler32_Update_Scalar;
-    end;
   end;
+{$ENDIF}
 end;
 
 initialization

--- a/HashLib/src/Crypto/HlpBlake2BDispatch.pas
+++ b/HashLib/src/Crypto/HlpBlake2BDispatch.pas
@@ -119,8 +119,9 @@ end;
 
 procedure InitDispatch();
 begin
-  case TSimd.GetActiveLevel() of
+  Blake2B_Compress := @Blake2B_Compress_Scalar;
 {$IFDEF HASHLIB_X86_64}
+  case TSimd.GetActiveLevel() of
     TSimdLevel.AVX2:
     begin
       Blake2B_Compress := @Blake2B_Compress_Avx2;
@@ -129,12 +130,8 @@ begin
     begin
       Blake2B_Compress := @Blake2B_Compress_Sse2;
     end;
-{$ENDIF}
-    TSimdLevel.Scalar:
-    begin
-      Blake2B_Compress := @Blake2B_Compress_Scalar;
-    end;
   end;
+{$ENDIF}
 end;
 
 initialization

--- a/HashLib/src/Crypto/HlpBlake2SDispatch.pas
+++ b/HashLib/src/Crypto/HlpBlake2SDispatch.pas
@@ -117,8 +117,9 @@ end;
 
 procedure InitDispatch();
 begin
-  case TSimd.GetActiveLevel() of
+  Blake2S_Compress := @Blake2S_Compress_Scalar;
 {$IFDEF HASHLIB_X86_64}
+  case TSimd.GetActiveLevel() of
     TSimdLevel.AVX2:
     begin
       Blake2S_Compress := @Blake2S_Compress_Avx2;
@@ -127,12 +128,8 @@ begin
     begin
       Blake2S_Compress := @Blake2S_Compress_Sse2;
     end;
-{$ENDIF}
-    TSimdLevel.Scalar:
-    begin
-      Blake2S_Compress := @Blake2S_Compress_Scalar;
-    end;
   end;
+{$ENDIF}
 end;
 
 initialization

--- a/HashLib/src/Crypto/HlpBlake3Dispatch.pas
+++ b/HashLib/src/Crypto/HlpBlake3Dispatch.pas
@@ -687,12 +687,11 @@ end;
 
 procedure InitDispatch();
 begin
-  // HashMany always has a scalar fallback available
+  Blake3_Compress := @Blake3_Compress_Scalar;
   Blake3_HashMany := @Blake3_HashMany_Scalar;
   Blake3_ParallelDegree := 1;
-
-  case TSimd.GetActiveLevel() of
 {$IFDEF HASHLIB_X86_64}
+  case TSimd.GetActiveLevel() of
     TSimdLevel.AVX2:
     begin
       Blake3_Compress := @Blake3_Compress_Avx2;
@@ -705,12 +704,8 @@ begin
       Blake3_HashMany := @Blake3_HashMany_Sse2;
       Blake3_ParallelDegree := 4;
     end;
-{$ENDIF}
-    TSimdLevel.Scalar:
-    begin
-      Blake3_Compress := @Blake3_Compress_Scalar;
-    end;
   end;
+{$ENDIF}
 end;
 
 initialization

--- a/HashLib/src/Crypto/HlpSHA1Dispatch.pas
+++ b/HashLib/src/Crypto/HlpSHA1Dispatch.pas
@@ -153,15 +153,14 @@ end;
 
 procedure InitDispatch();
 begin
+  SHA1_Compress := @SHA1_Compress_Scalar;
 {$IFDEF HASHLIB_X86_64}
   if TSimd.HasSHANI() then
   begin
     SHA1_Compress := @SHA1_Compress_ShaNi_Wrap;
     Exit;
   end;
-{$ENDIF}
   case TSimd.GetActiveLevel() of
-{$IFDEF HASHLIB_X86_64}
     TSimdLevel.AVX2:
     begin
       SHA1_Compress := @SHA1_Compress_Avx2_Wrap;
@@ -174,12 +173,8 @@ begin
     begin
       SHA1_Compress := @SHA1_Compress_Sse2;
     end;
-{$ENDIF}
-    TSimdLevel.Scalar:
-    begin
-      SHA1_Compress := @SHA1_Compress_Scalar;
-    end;
   end;
+{$ENDIF}
 end;
 
 initialization

--- a/HashLib/src/Crypto/HlpSHA2_256Dispatch.pas
+++ b/HashLib/src/Crypto/HlpSHA2_256Dispatch.pas
@@ -154,15 +154,14 @@ end;
 
 procedure InitDispatch();
 begin
+  SHA256_Compress := @SHA256_Compress_Scalar;
 {$IFDEF HASHLIB_X86_64}
   if TSimd.HasSHANI() then
   begin
     SHA256_Compress := @SHA256_Compress_ShaNi_Wrap;
     Exit;
   end;
-{$ENDIF}
   case TSimd.GetActiveLevel() of
-{$IFDEF HASHLIB_X86_64}
     TSimdLevel.AVX2:
     begin
       SHA256_Compress := @SHA256_Compress_Avx2_Wrap;
@@ -175,12 +174,8 @@ begin
     begin
       SHA256_Compress := @SHA256_Compress_Sse2_Wrap;
     end;
-{$ENDIF}
-    TSimdLevel.Scalar:
-    begin
-      SHA256_Compress := @SHA256_Compress_Scalar;
-    end;
   end;
+{$ENDIF}
 end;
 
 initialization

--- a/HashLib/src/Crypto/HlpSHA2_512Dispatch.pas
+++ b/HashLib/src/Crypto/HlpSHA2_512Dispatch.pas
@@ -167,8 +167,9 @@ end;
 
 procedure InitDispatch();
 begin
-  case TSimd.GetActiveLevel() of
+  SHA512_Compress := @SHA512_Compress_Scalar;
 {$IFDEF HASHLIB_X86_64}
+  case TSimd.GetActiveLevel() of
     TSimdLevel.AVX2:
     begin
       SHA512_Compress := @SHA512_Compress_Avx2_Wrap;
@@ -181,12 +182,8 @@ begin
     begin
       SHA512_Compress := @SHA512_Compress_Sse2_Wrap;
     end;
-{$ENDIF}
-    TSimdLevel.Scalar:
-    begin
-      SHA512_Compress := @SHA512_Compress_Scalar;
-    end;
   end;
+{$ENDIF}
 end;
 
 initialization

--- a/HashLib/src/Crypto/HlpSHA3Dispatch.pas
+++ b/HashLib/src/Crypto/HlpSHA3Dispatch.pas
@@ -493,20 +493,17 @@ end;
 
 procedure InitDispatch();
 begin
-  case TSimd.GetActiveLevel() of
+  KeccakF1600_Permute := @KeccakF1600_Scalar;
+  KeccakF1600_Absorb := @KeccakF1600_Absorb_Scalar;
 {$IFDEF HASHLIB_X86_64}
+  case TSimd.GetActiveLevel() of
     TSimdLevel.AVX2:
     begin
       KeccakF1600_Permute := @KeccakF1600_Avx2_Wrap;
       KeccakF1600_Absorb := @KeccakF1600_Avx2_Absorb_Wrap;
     end;
-{$ENDIF}
-    TSimdLevel.Scalar:
-    begin
-      KeccakF1600_Permute := @KeccakF1600_Scalar;
-      KeccakF1600_Absorb := @KeccakF1600_Absorb_Scalar;
-    end;
   end;
+{$ENDIF}
 end;
 
 initialization

--- a/HashLib/src/Hash64/HlpXXHash3Dispatch.pas
+++ b/HashLib/src/Hash64/HlpXXHash3Dispatch.pas
@@ -174,8 +174,12 @@ end;
 
 procedure InitDispatch();
 begin
-  case TSimd.GetActiveLevel() of
+  XXH3_Accumulate512 := @XXH3_Accumulate512_Scalar;
+  XXH3_Accumulate := @XXH3_Accumulate_Scalar;
+  XXH3_ScrambleAcc := @XXH3_ScrambleAcc_Scalar;
+  XXH3_InitSecret := @XXH3_InitSecret_Scalar;
 {$IFDEF HASHLIB_X86_64}
+  case TSimd.GetActiveLevel() of
     TSimdLevel.AVX2:
     begin
       XXH3_Accumulate512 := @XXH3_Accumulate512_Avx2;
@@ -190,15 +194,8 @@ begin
       XXH3_ScrambleAcc := @XXH3_ScrambleAcc_Sse2;
       XXH3_InitSecret := @XXH3_InitSecret_Sse2;
     end;
-{$ENDIF}
-    TSimdLevel.Scalar:
-    begin
-      XXH3_Accumulate512 := @XXH3_Accumulate512_Scalar;
-      XXH3_Accumulate := @XXH3_Accumulate_Scalar;
-      XXH3_ScrambleAcc := @XXH3_ScrambleAcc_Scalar;
-      XXH3_InitSecret := @XXH3_InitSecret_Scalar;
-    end;
   end;
+{$ENDIF}
 end;
 
 initialization

--- a/HashLib/src/KDF/HlpArgon2Dispatch.pas
+++ b/HashLib/src/KDF/HlpArgon2Dispatch.pas
@@ -125,8 +125,9 @@ end;
 
 procedure InitDispatch();
 begin
-  case TSimd.GetActiveLevel() of
+  Argon2_FillBlock := @Argon2_FillBlock_Scalar;
 {$IFDEF HASHLIB_X86_64}
+  case TSimd.GetActiveLevel() of
     TSimdLevel.AVX2:
     begin
       Argon2_FillBlock := @Argon2_FillBlock_Avx2;
@@ -135,12 +136,8 @@ begin
     begin
       Argon2_FillBlock := @Argon2_FillBlock_Sse2;
     end;
-{$ENDIF}
-    TSimdLevel.Scalar:
-    begin
-      Argon2_FillBlock := @Argon2_FillBlock_Scalar;
-    end;
   end;
+{$ENDIF}
 end;
 
 initialization

--- a/HashLib/src/KDF/HlpScryptDispatch.pas
+++ b/HashLib/src/KDF/HlpScryptDispatch.pas
@@ -190,8 +190,9 @@ end;
 
 procedure InitDispatch();
 begin
-  case TSimd.GetActiveLevel() of
+  Scrypt_SalsaXor := @Scrypt_SalsaXor_Scalar;
 {$IFDEF HASHLIB_X86_64}
+  case TSimd.GetActiveLevel() of
     TSimdLevel.AVX2:
     begin
       Scrypt_SalsaXor := @Scrypt_SalsaXor_Avx2;
@@ -200,12 +201,8 @@ begin
     begin
       Scrypt_SalsaXor := @Scrypt_SalsaXor_Sse2;
     end;
-{$ENDIF}
-    TSimdLevel.Scalar:
-    begin
-      Scrypt_SalsaXor := @Scrypt_SalsaXor_Scalar;
-    end;
   end;
+{$ENDIF}
 end;
 
 initialization


### PR DESCRIPTION
## Summary
- Restructures all 11 `InitDispatch` procedures to assign scalar function pointers as the default **before** the SIMD `case` statement, which is now entirely wrapped in `{$IFDEF HASHLIB_X86_64}`.
- **Fixes** SHA3/Keccak tests failing when `HASHLIB_FORCE_SSE2` or `HASHLIB_FORCE_SSSE3` is defined — the `case` had no branch for those levels, so `KeccakF1600_Permute` and `KeccakF1600_Absorb` were never assigned.
- Hardens all other dispatchers (SHA1, SHA2-256, SHA2-512, Blake2S, Blake2B, Blake3, Adler32, XXHash3, Argon2, Scrypt) with the same pattern for consistency and future-proofing against new SIMD levels.