### PR TITLE
introduce HASHLIB_X86_64_ASM define for inline assembly support

### DIFF
--- a/HashLib/src/Checksum/HlpAdler32Dispatch.pas
+++ b/HashLib/src/Checksum/HlpAdler32Dispatch.pas
@@ -67,7 +67,7 @@ end;
 // SIMD implementations (x86-64 only)
 // =============================================================================
 
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
 
 type
   TProcessBlocksProc = procedure(AData: PByte; ANumBlocks: UInt32;
@@ -145,7 +145,7 @@ begin
   Adler32_Update_Simd(AData, ALength, ASums, @Adler32_ProcessBlocks_Avx2);
 end;
 
-{$ENDIF HASHLIB_X86_64}
+{$ENDIF HASHLIB_X86_64_ASM}
 
 // =============================================================================
 // Dispatch initialization
@@ -154,7 +154,7 @@ end;
 procedure InitDispatch();
 begin
   Adler32_Update := @Adler32_Update_Scalar;
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
   case TSimd.GetActiveLevel() of
     TSimdLevel.AVX2:
     begin

--- a/HashLib/src/Checksum/HlpCRCDispatch.pas
+++ b/HashLib/src/Checksum/HlpCRCDispatch.pas
@@ -24,7 +24,7 @@ implementation
 uses
   HlpSimd;
 
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
 
 function CRC_Fold_Pclmul(AData: PByte; ALength: UInt32;
   AState: Pointer; AConstants: Pointer): UInt64;
@@ -50,13 +50,13 @@ function CRC_Fold_Vpclmul_Msb(AData: PByte; ALength: UInt32;
   {$I ..\Include\Simd\CRC\CRCFoldVpclmulMsb.inc}
 end;
 
-{$ENDIF HASHLIB_X86_64}
+{$ENDIF HASHLIB_X86_64_ASM}
 
 procedure InitDispatch();
 begin
   CRC_Fold_Lsb := nil;
   CRC_Fold_Msb := nil;
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
   if TSimd.HasVPCLMULQDQ() then
   begin
     CRC_Fold_Lsb := @CRC_Fold_Vpclmul;

--- a/HashLib/src/Crypto/HlpBlake2BDispatch.pas
+++ b/HashLib/src/Crypto/HlpBlake2BDispatch.pas
@@ -99,7 +99,7 @@ end;
 // SSE2 and AVX2 implementations (x86-64 only)
 // =============================================================================
 
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
 
 procedure Blake2B_Compress_Sse2(AState, AMsg, ACounterFlags, AIV: Pointer);
   {$I ..\Include\Simd\Common\SimdProc4Begin.inc}
@@ -111,7 +111,7 @@ procedure Blake2B_Compress_Avx2(AState, AMsg, ACounterFlags, AIV: Pointer);
   {$I ..\Include\Simd\Blake2B\Blake2BCompressAvx2.inc}
 end;
 
-{$ENDIF HASHLIB_X86_64}
+{$ENDIF HASHLIB_X86_64_ASM}
 
 // =============================================================================
 // Dispatch initialization
@@ -120,7 +120,7 @@ end;
 procedure InitDispatch();
 begin
   Blake2B_Compress := @Blake2B_Compress_Scalar;
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
   case TSimd.GetActiveLevel() of
     TSimdLevel.AVX2:
     begin

--- a/HashLib/src/Crypto/HlpBlake2SDispatch.pas
+++ b/HashLib/src/Crypto/HlpBlake2SDispatch.pas
@@ -97,7 +97,7 @@ end;
 // SSE2 and AVX2 implementations (x86-64 only)
 // =============================================================================
 
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
 
 procedure Blake2S_Compress_Sse2(AState, AMsg, ACounterFlags, AIV: Pointer);
   {$I ..\Include\Simd\Common\SimdProc4Begin.inc}
@@ -109,7 +109,7 @@ procedure Blake2S_Compress_Avx2(AState, AMsg, ACounterFlags, AIV: Pointer);
   {$I ..\Include\Simd\Blake2S\Blake2SCompressAvx2.inc}
 end;
 
-{$ENDIF HASHLIB_X86_64}
+{$ENDIF HASHLIB_X86_64_ASM}
 
 // =============================================================================
 // Dispatch initialization
@@ -118,7 +118,7 @@ end;
 procedure InitDispatch();
 begin
   Blake2S_Compress := @Blake2S_Compress_Scalar;
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
   case TSimd.GetActiveLevel() of
     TSimdLevel.AVX2:
     begin

--- a/HashLib/src/Crypto/HlpBlake3Dispatch.pas
+++ b/HashLib/src/Crypto/HlpBlake3Dispatch.pas
@@ -613,7 +613,7 @@ end;
 // SSE2 and AVX2 implementations (x86-64 only)
 // =============================================================================
 
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
 
 procedure Blake3_Compress_Sse2(AState, AMsg, ACV, ACounterFlags: Pointer);
   {$I ..\Include\Simd\Common\SimdProc4Begin.inc}
@@ -679,7 +679,7 @@ begin
     Blake3_HashMany_Sse2(LPInput, AKey, LPOut, ANumChunks, ACounter, AFlags);
 end;
 
-{$ENDIF HASHLIB_X86_64}
+{$ENDIF HASHLIB_X86_64_ASM}
 
 // =============================================================================
 // Dispatch initialization
@@ -690,7 +690,7 @@ begin
   Blake3_Compress := @Blake3_Compress_Scalar;
   Blake3_HashMany := @Blake3_HashMany_Scalar;
   Blake3_ParallelDegree := 1;
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
   case TSimd.GetActiveLevel() of
     TSimdLevel.AVX2:
     begin

--- a/HashLib/src/Crypto/HlpSHA1Dispatch.pas
+++ b/HashLib/src/Crypto/HlpSHA1Dispatch.pas
@@ -105,7 +105,7 @@ end;
 // SIMD implementations (x86-64 only)
 // =============================================================================
 
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
 
 procedure SHA1_Compress_ShaNi(AState, AData: Pointer; ANumBlocks: UInt32;
   AConstants: Pointer);
@@ -145,7 +145,7 @@ begin
   SHA1_Compress_Avx2(AState, AData, ANumBlocks, @K_SHA1);
 end;
 
-{$ENDIF HASHLIB_X86_64}
+{$ENDIF HASHLIB_X86_64_ASM}
 
 // =============================================================================
 // Dispatch initialization
@@ -154,7 +154,7 @@ end;
 procedure InitDispatch();
 begin
   SHA1_Compress := @SHA1_Compress_Scalar;
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
   if TSimd.HasSHANI() then
   begin
     SHA1_Compress := @SHA1_Compress_ShaNi_Wrap;

--- a/HashLib/src/Crypto/HlpSHA2_256Dispatch.pas
+++ b/HashLib/src/Crypto/HlpSHA2_256Dispatch.pas
@@ -100,7 +100,7 @@ end;
 // SIMD implementations (x86-64 only)
 // =============================================================================
 
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
 
 procedure SHA256_Compress_ShaNi(AState, AData: Pointer; ANumBlocks: UInt32;
   AConstants: Pointer);
@@ -146,7 +146,7 @@ begin
   SHA256_Compress_Avx2(AState, AData, ANumBlocks, @K256);
 end;
 
-{$ENDIF HASHLIB_X86_64}
+{$ENDIF HASHLIB_X86_64_ASM}
 
 // =============================================================================
 // Dispatch initialization
@@ -155,7 +155,7 @@ end;
 procedure InitDispatch();
 begin
   SHA256_Compress := @SHA256_Compress_Scalar;
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
   if TSimd.HasSHANI() then
   begin
     SHA256_Compress := @SHA256_Compress_ShaNi_Wrap;

--- a/HashLib/src/Crypto/HlpSHA2_512Dispatch.pas
+++ b/HashLib/src/Crypto/HlpSHA2_512Dispatch.pas
@@ -124,7 +124,7 @@ end;
 // SIMD implementations (x86-64 only)
 // =============================================================================
 
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
 
 procedure SHA512_Compress_Sse2(AState, AData: Pointer; ANumBlocks: UInt32;
   AConstants: Pointer);
@@ -159,7 +159,7 @@ begin
   SHA512_Compress_Avx2(AState, AData, ANumBlocks, @K512);
 end;
 
-{$ENDIF HASHLIB_X86_64}
+{$ENDIF HASHLIB_X86_64_ASM}
 
 // =============================================================================
 // Dispatch initialization
@@ -168,7 +168,7 @@ end;
 procedure InitDispatch();
 begin
   SHA512_Compress := @SHA512_Compress_Scalar;
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
   case TSimd.GetActiveLevel() of
     TSimdLevel.AVX2:
     begin

--- a/HashLib/src/Crypto/HlpSHA3Dispatch.pas
+++ b/HashLib/src/Crypto/HlpSHA3Dispatch.pas
@@ -409,7 +409,7 @@ end;
 // SIMD implementations (x86-64 only)
 // =============================================================================
 
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
 
 const
   K_KECCAK: packed record
@@ -485,7 +485,7 @@ begin
   KeccakF1600_Avx2_Absorb(AState, AData, ABlockCount, ABlockSize, @K_KECCAK);
 end;
 
-{$ENDIF HASHLIB_X86_64}
+{$ENDIF HASHLIB_X86_64_ASM}
 
 // =============================================================================
 // Dispatch initialization
@@ -495,7 +495,7 @@ procedure InitDispatch();
 begin
   KeccakF1600_Permute := @KeccakF1600_Scalar;
   KeccakF1600_Absorb := @KeccakF1600_Absorb_Scalar;
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
   case TSimd.GetActiveLevel() of
     TSimdLevel.AVX2:
     begin

--- a/HashLib/src/Hash64/HlpXXHash3Dispatch.pas
+++ b/HashLib/src/Hash64/HlpXXHash3Dispatch.pas
@@ -106,7 +106,7 @@ end;
 // SSE2 and AVX2 implementations (x86-64 only)
 // =============================================================================
 
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
 
 // ----- SSE2 -----
 
@@ -166,7 +166,7 @@ begin
       PByte(ASecret) + N * XXH_SECRET_CONSUME_RATE);
 end;
 
-{$ENDIF HASHLIB_X86_64}
+{$ENDIF HASHLIB_X86_64_ASM}
 
 // =============================================================================
 // Dispatch initialization
@@ -178,7 +178,7 @@ begin
   XXH3_Accumulate := @XXH3_Accumulate_Scalar;
   XXH3_ScrambleAcc := @XXH3_ScrambleAcc_Scalar;
   XXH3_InitSecret := @XXH3_InitSecret_Scalar;
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
   case TSimd.GetActiveLevel() of
     TSimdLevel.AVX2:
     begin

--- a/HashLib/src/Include/HashLib.inc
+++ b/HashLib/src/Include/HashLib.inc
@@ -47,6 +47,9 @@
 
 {$IF DEFINED(CPUX64)}
   {$DEFINE HASHLIB_X86_64}
+  {$IFDEF MSWINDOWS}
+    {$DEFINE HASHLIB_X86_64_ASM}
+  {$ENDIF}
 {$IFEND}
 
 {$ENDIF}
@@ -65,7 +68,7 @@
 // Uncomment to force scalar dispatch (available on all platforms):
 // {$DEFINE HASHLIB_FORCE_SCALAR}
 
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
 // Uncomment ONE to force a specific x86-64 SIMD dispatch level:
 // {$DEFINE HASHLIB_FORCE_SSE2}
 // {$DEFINE HASHLIB_FORCE_SSSE3}

--- a/HashLib/src/Include/HashLibFPC.inc
+++ b/HashLib/src/Include/HashLibFPC.inc
@@ -40,6 +40,7 @@
 
 {$IF DEFINED(CPUX64)}
   {$DEFINE HASHLIB_X86_64}
+  {$DEFINE HASHLIB_X86_64_ASM}
 {$IFEND}
 
 {========================= Compiler Mode & Optimizations ======================}

--- a/HashLib/src/KDF/HlpArgon2Dispatch.pas
+++ b/HashLib/src/KDF/HlpArgon2Dispatch.pas
@@ -105,7 +105,7 @@ end;
 // SSE2 and AVX2 implementations (x86-64 only)
 // =============================================================================
 
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
 
 procedure Argon2_FillBlock_Sse2(ALeft, ARight, ACurrent: Pointer; AWithXor: Int32);
   {$I ..\Include\Simd\Common\SimdProc4Begin.inc}
@@ -117,7 +117,7 @@ procedure Argon2_FillBlock_Avx2(ALeft, ARight, ACurrent: Pointer; AWithXor: Int3
   {$I ..\Include\Simd\Argon2\Argon2FillBlockAvx2.inc}
 end;
 
-{$ENDIF HASHLIB_X86_64}
+{$ENDIF HASHLIB_X86_64_ASM}
 
 // =============================================================================
 // Dispatch initialization
@@ -126,7 +126,7 @@ end;
 procedure InitDispatch();
 begin
   Argon2_FillBlock := @Argon2_FillBlock_Scalar;
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
   case TSimd.GetActiveLevel() of
     TSimdLevel.AVX2:
     begin

--- a/HashLib/src/KDF/HlpScryptDispatch.pas
+++ b/HashLib/src/KDF/HlpScryptDispatch.pas
@@ -170,7 +170,7 @@ end;
 // SSE2 and AVX2 implementations (x86-64 only)
 // =============================================================================
 
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
 
 procedure Scrypt_SalsaXor_Sse2(AState, AInput: Pointer);
   {$I ..\Include\Simd\Common\SimdProc2Begin.inc}
@@ -182,7 +182,7 @@ procedure Scrypt_SalsaXor_Avx2(AState, AInput: Pointer);
   {$I ..\Include\Simd\Scrypt\ScryptSalsa8Avx2.inc}
 end;
 
-{$ENDIF HASHLIB_X86_64}
+{$ENDIF HASHLIB_X86_64_ASM}
 
 // =============================================================================
 // Dispatch initialization
@@ -191,7 +191,7 @@ end;
 procedure InitDispatch();
 begin
   Scrypt_SalsaXor := @Scrypt_SalsaXor_Scalar;
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
   case TSimd.GetActiveLevel() of
     TSimdLevel.AVX2:
     begin

--- a/HashLib/src/Utils/HlpSimd.pas
+++ b/HashLib/src/Utils/HlpSimd.pas
@@ -29,7 +29,7 @@ type
 
 implementation
 
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
 
 type
   TCpuIdResult = record
@@ -101,17 +101,17 @@ asm
 end;
 {$ENDIF}
 
-{$ENDIF HASHLIB_X86_64}
+{$ENDIF HASHLIB_X86_64_ASM}
 
 { TSimd }
 
 class function TSimd.CPUHasSSE2(): Boolean;
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
 var
   LCpuId: TCpuIdResult;
 {$ENDIF}
 begin
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
   CpuIdQuery(1, 0, @LCpuId);
   Result := (LCpuId.RegEDX and (1 shl 26)) <> 0;
 {$ELSE}
@@ -120,12 +120,12 @@ begin
 end;
 
 class function TSimd.CPUHasSSSE3(): Boolean;
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
 var
   LCpuId: TCpuIdResult;
 {$ENDIF}
 begin
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
   CpuIdQuery(1, 0, @LCpuId);
   // SSSE3: ECX bit 9
   Result := (LCpuId.RegECX and (1 shl 9)) <> 0;
@@ -135,13 +135,13 @@ begin
 end;
 
 class function TSimd.CPUHasAVX2(): Boolean;
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
 var
   LCpuId: TCpuIdResult;
   LXcr0: UInt64;
 {$ENDIF}
 begin
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
   CpuIdQuery(1, 0, @LCpuId);
 
   // OSXSAVE: ECX bit 27 (required for OS AVX state saving)
@@ -164,12 +164,12 @@ begin
 end;
 
 class function TSimd.CPUHasSHANI(): Boolean;
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
 var
   LCpuId: TCpuIdResult;
 {$ENDIF}
 begin
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
   CpuIdQuery(7, 0, @LCpuId);
   // SHA-NI: EBX bit 29
   Result := (LCpuId.RegEBX and (1 shl 29)) <> 0;
@@ -179,12 +179,12 @@ begin
 end;
 
 class function TSimd.CPUHasPCLMULQDQ(): Boolean;
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
 var
   LCpuId: TCpuIdResult;
 {$ENDIF}
 begin
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
   CpuIdQuery(1, 0, @LCpuId);
   // PCLMULQDQ: ECX bit 1
   Result := (LCpuId.RegECX and (1 shl 1)) <> 0;
@@ -194,12 +194,12 @@ begin
 end;
 
 class function TSimd.CPUHasVPCLMULQDQ(): Boolean;
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
 var
   LCpuId: TCpuIdResult;
 {$ENDIF}
 begin
-{$IFDEF HASHLIB_X86_64}
+{$IFDEF HASHLIB_X86_64_ASM}
   CpuIdQuery(7, 0, @LCpuId);
   // VPCLMULQDQ: ECX bit 10
   Result := (LCpuId.RegECX and (1 shl 10)) <> 0;


### PR DESCRIPTION
Separate architecture detection (HASHLIB_X86_64) from inline assembly availability (HASHLIB_X86_64_ASM). Delphi compiler only supports inline ASM on Windows, so HASHLIB_X86_64_ASM is gated behind CPUX64 + MSWINDOWS for Delphi, while FPC sets it unconditionally on CPUX64 since it supports ASM on all platforms. All SIMD code and dispatch logic now uses the new define, fixing Delphi Linux x86-64 compilation (E1025 Unsupported language feature: 'ASM').

closes #54 