### PR TITLE
Move SIMD CPU-detection assembly from HlpSimd.pas to dedicated .inc f…

### DIFF
--- a/HashLib/src/Include/Simd/CpuDetect/CpuIdQuery.inc
+++ b/HashLib/src/Include/Simd/CpuDetect/CpuIdQuery.inc
@@ -1,0 +1,39 @@
+// CPUID query: executes CPUID with leaf=ALeaf, subleaf=ASubLeaf,
+// stores EAX/EBX/ECX/EDX into the TCpuIdResult record at AResult.
+// RBX must be preserved (CPUID clobbers it).
+// Expects MS x64 ABI: ecx = ALeaf, edx = ASubLeaf, r8 = AResult.
+// On FPC non-Windows (System V ABI), remaps edi,esi,rdx -> ecx,edx,r8.
+{$IFDEF FPC}
+  assembler; nostackframe;
+asm
+  push rbx
+  {$IFDEF MSWINDOWS}
+  mov eax, ecx
+  mov ecx, edx
+  cpuid
+  mov dword ptr [r8], eax
+  mov dword ptr [r8 + 4], ebx
+  mov dword ptr [r8 + 8], ecx
+  mov dword ptr [r8 + 12], edx
+  {$ELSE}
+  mov eax, edi
+  mov ecx, esi
+  mov r8, rdx
+  cpuid
+  mov dword ptr [r8], eax
+  mov dword ptr [r8 + 4], ebx
+  mov dword ptr [r8 + 8], ecx
+  mov dword ptr [r8 + 12], edx
+  {$ENDIF}
+  pop rbx
+{$ELSE}
+asm
+  .PUSHNV RBX
+  mov eax, ecx
+  mov ecx, edx
+  cpuid
+  mov dword ptr [r8], eax
+  mov dword ptr [r8 + 4], ebx
+  mov dword ptr [r8 + 8], ecx
+  mov dword ptr [r8 + 12], edx
+{$ENDIF}

--- a/HashLib/src/Include/Simd/CpuDetect/XGetBvQuery.inc
+++ b/HashLib/src/Include/Simd/CpuDetect/XGetBvQuery.inc
@@ -1,0 +1,25 @@
+// XGETBV query: executes XGETBV with ECX=0, stores EAX:EDX into the
+// UInt64 at AResult.
+// Expects MS x64 ABI: rcx = AResult.
+// On FPC non-Windows (System V ABI), remaps rdi -> rcx.
+{$IFDEF FPC}
+  assembler; nostackframe;
+asm
+  {$IFDEF MSWINDOWS}
+  mov r8, rcx
+  {$ELSE}
+  mov r8, rdi
+  {$ENDIF}
+  xor ecx, ecx
+  xgetbv
+  mov dword ptr [r8], eax
+  mov dword ptr [r8 + 4], edx
+{$ELSE}
+asm
+  .noframe
+  mov r8, rcx
+  xor ecx, ecx
+  xgetbv
+  mov dword ptr [r8], eax
+  mov dword ptr [r8 + 4], edx
+{$ENDIF}

--- a/HashLib/src/Utils/HlpSimd.pas
+++ b/HashLib/src/Utils/HlpSimd.pas
@@ -36,70 +36,13 @@ type
     RegEAX, RegEBX, RegECX, RegEDX: UInt32;
   end;
 
-{$IFDEF FPC}
 procedure CpuIdQuery(ALeaf, ASubLeaf: UInt32; AResult: Pointer);
-  assembler; nostackframe;
-asm
-  push rbx
-  {$IFDEF MSWINDOWS}
-  mov eax, ecx
-  mov ecx, edx
-  cpuid
-  mov dword ptr [r8], eax
-  mov dword ptr [r8 + 4], ebx
-  mov dword ptr [r8 + 8], ecx
-  mov dword ptr [r8 + 12], edx
-  {$ELSE}
-  mov eax, edi
-  mov ecx, esi
-  mov r8, rdx
-  cpuid
-  mov dword ptr [r8], eax
-  mov dword ptr [r8 + 4], ebx
-  mov dword ptr [r8 + 8], ecx
-  mov dword ptr [r8 + 12], edx
-  {$ENDIF}
-  pop rbx
+  {$I ..\Include\Simd\CpuDetect\CpuIdQuery.inc}
 end;
-{$ELSE}
-procedure CpuIdQuery(ALeaf, ASubLeaf: UInt32; AResult: Pointer);
-asm
-  .PUSHNV RBX
-  mov eax, ecx
-  mov ecx, edx
-  cpuid
-  mov dword ptr [r8], eax
-  mov dword ptr [r8 + 4], ebx
-  mov dword ptr [r8 + 8], ecx
-  mov dword ptr [r8 + 12], edx
-end;
-{$ENDIF}
 
-{$IFDEF FPC}
 procedure XGetBvQuery(AResult: Pointer);
-  assembler; nostackframe;
-asm
-  {$IFDEF MSWINDOWS}
-  mov r8, rcx
-  {$ELSE}
-  mov r8, rdi
-  {$ENDIF}
-  xor ecx, ecx
-  xgetbv
-  mov dword ptr [r8], eax
-  mov dword ptr [r8 + 4], edx
+  {$I ..\Include\Simd\CpuDetect\XGetBvQuery.inc}
 end;
-{$ELSE}
-procedure XGetBvQuery(AResult: Pointer);
-asm
-  .noframe
-  mov r8, rcx
-  xor ecx, ecx
-  xgetbv
-  mov dword ptr [r8], eax
-  mov dword ptr [r8 + 4], edx
-end;
-{$ENDIF}
 
 {$ENDIF HASHLIB_X86_64_ASM}
 


### PR DESCRIPTION
- Move SIMD CPU-detection assembly from HlpSimd.pas to dedicated .inc files

Extract the inline CpuIdQuery and XGetBvQuery assembly bodies into Include/Simd/CpuDetect/CpuIdQuery.inc and XGetBvQuery.inc, replacing the dual FPC/Delphi asm blocks with {$I} includes.