### PR TITLE
BREAKING: normalize enum member names (hash size/rounds, SHA3 mode, G…

### DIFF
--- a/HashLib.Tests/src/CryptoTests.pas
+++ b/HashLib.Tests/src/CryptoTests.pas
@@ -937,7 +937,7 @@ end;
 procedure TTestGost_CryptoProParamSet.SetUp;
 begin
   inherited;
-  HashInstance := THashFactory.TCrypto.CreateGost(TGostSBox.gsbCryptoProParamSet);
+  HashInstance := THashFactory.TCrypto.CreateGost(TGost.TSBoxType.CryptoProParamSet);
   HmacInstance := THashFactory.THMAC.CreateHMAC(HashInstance);
   HashOfEmptyData :=
     '981E5F3CA30C841487830F84FB433E13AC1101569B9C13584AC483234CD656C0';

--- a/HashLib.Tests/src/PBKDF_Argon2Tests.pas
+++ b/HashLib.Tests/src/PBKDF_Argon2Tests.pas
@@ -117,7 +117,7 @@ begin
   LPassword :=
     '0101010101010101010101010101010101010101010101010101010101010101';
 
-  Argon2Version := TArgon2Version.a2vARGON2_VERSION_13;
+  Argon2Version := TArgon2Version.Version13;
 
   Argon2ParametersBuilder := TArgon2dParametersBuilder.Builder();
 
@@ -185,7 +185,7 @@ var
   Argon2Version: TArgon2Version;
 begin
 
-  Argon2Version := TArgon2Version.a2vARGON2_VERSION_10;
+  Argon2Version := TArgon2Version.Version10;
   Argon2ParametersBuilder := TArgon2iParametersBuilder.Builder();
   // Multiple test cases for various input values
   HashTestOthers(Argon2ParametersBuilder, Argon2Version, 2, 16, 1, 'password',
@@ -234,7 +234,7 @@ begin
     + '39FEBA4A9CD9CC5B4C798F2AAF70EB4BD044C8D148DECB569870DBD923430B82A083F284BEAE777812CCE18CDAC68EE8CCEF'
     + 'C6EC9789F30A6B5A034591F51AF830F4', 112);
 
-  Argon2Version := TArgon2Version.a2vARGON2_VERSION_13;
+  Argon2Version := TArgon2Version.Version13;
   Argon2ParametersBuilder := TArgon2iParametersBuilder.Builder();
   // Multiple test cases for various input values
 

--- a/HashLib/src/Base/HlpHashFactory.pas
+++ b/HashLib/src/Base/HlpHashFactory.pas
@@ -371,8 +371,8 @@ type
       class function CreateHaval_4_256(): IHash; static;
       class function CreateHaval_5_256(): IHash; static;
 
-      class function CreateGost(ASBoxType: TGostSBox = TGostSBox.gsbTestParamSet)
-        : IHash; static;
+      class function CreateGost(
+        ASBoxType: TGost.TSBoxType = TGost.TSBoxType.TestParamSet): IHash; static;
       class function CreateGost_CryptoProParamSet(): IHash; static;
 
       // Streebog 256
@@ -878,14 +878,14 @@ end;
 
 { THashFactory.TCrypto }
 
-class function THashFactory.TCrypto.CreateGost(ASBoxType: TGostSBox): IHash;
+class function THashFactory.TCrypto.CreateGost(ASBoxType: TGost.TSBoxType): IHash;
 begin
   Result := TGost.Create(ASBoxType);
 end;
 
 class function THashFactory.TCrypto.CreateGost_CryptoProParamSet: IHash;
 begin
-  Result := TGost.Create(TGostSBox.gsbCryptoProParamSet);
+  Result := TGost.Create(TGost.TSBoxType.CryptoProParamSet);
 end;
 
 class function THashFactory.TCrypto.CreateGOST3411_2012_256: IHash;
@@ -917,49 +917,49 @@ class function THashFactory.TCrypto.CreateHaval(ARounds: THashRounds;
   AHashSize: THashSize): IHash;
 begin
   case ARounds of
-    THashRounds.hrRounds3:
+    THashRounds.Rounds3:
       case AHashSize of
-        THashSize.hsHashSize128:
+        THashSize.Size128:
           Result := CreateHaval_3_128();
-        THashSize.hsHashSize160:
+        THashSize.Size160:
           Result := CreateHaval_3_160();
-        THashSize.hsHashSize192:
+        THashSize.Size192:
           Result := CreateHaval_3_192();
-        THashSize.hsHashSize224:
+        THashSize.Size224:
           Result := CreateHaval_3_224();
-        THashSize.hsHashSize256:
+        THashSize.Size256:
           Result := CreateHaval_3_256();
       else
         raise EArgumentHashLibException.CreateRes(@SInvalidHavalHashSize);
       end;
 
-    THashRounds.hrRounds4:
+    THashRounds.Rounds4:
       case AHashSize of
-        THashSize.hsHashSize128:
+        THashSize.Size128:
           Result := CreateHaval_4_128();
-        THashSize.hsHashSize160:
+        THashSize.Size160:
           Result := CreateHaval_4_160();
-        THashSize.hsHashSize192:
+        THashSize.Size192:
           Result := CreateHaval_4_192();
-        THashSize.hsHashSize224:
+        THashSize.Size224:
           Result := CreateHaval_4_224();
-        THashSize.hsHashSize256:
+        THashSize.Size256:
           Result := CreateHaval_4_256();
       else
         raise EArgumentHashLibException.CreateRes(@SInvalidHavalHashSize);
       end;
 
-    THashRounds.hrRounds5:
+    THashRounds.Rounds5:
       case AHashSize of
-        THashSize.hsHashSize128:
+        THashSize.Size128:
           Result := CreateHaval_5_128();
-        THashSize.hsHashSize160:
+        THashSize.Size160:
           Result := CreateHaval_5_160();
-        THashSize.hsHashSize192:
+        THashSize.Size192:
           Result := CreateHaval_5_192();
-        THashSize.hsHashSize224:
+        THashSize.Size224:
           Result := CreateHaval_5_224();
-        THashSize.hsHashSize256:
+        THashSize.Size256:
           Result := CreateHaval_5_256();
       else
         raise EArgumentHashLibException.CreateRes(@SInvalidHavalHashSize);
@@ -1201,25 +1201,25 @@ end;
 class function THashFactory.TCrypto.CreateBlake2B_160: IHash;
 begin
   Result := THashFactory.TCrypto.CreateBlake2B
-    (TBlake2BConfig.Create(THashSize.hsHashSize160) as IBlake2BConfig);
+    (TBlake2BConfig.Create(THashSize.Size160) as IBlake2BConfig);
 end;
 
 class function THashFactory.TCrypto.CreateBlake2B_256: IHash;
 begin
   Result := THashFactory.TCrypto.CreateBlake2B
-    (TBlake2BConfig.Create(THashSize.hsHashSize256) as IBlake2BConfig);
+    (TBlake2BConfig.Create(THashSize.Size256) as IBlake2BConfig);
 end;
 
 class function THashFactory.TCrypto.CreateBlake2B_384: IHash;
 begin
   Result := THashFactory.TCrypto.CreateBlake2B
-    (TBlake2BConfig.Create(THashSize.hsHashSize384) as IBlake2BConfig);
+    (TBlake2BConfig.Create(THashSize.Size384) as IBlake2BConfig);
 end;
 
 class function THashFactory.TCrypto.CreateBlake2B_512: IHash;
 begin
   Result := THashFactory.TCrypto.CreateBlake2B
-    (TBlake2BConfig.Create(THashSize.hsHashSize512) as IBlake2BConfig);
+    (TBlake2BConfig.Create(THashSize.Size512) as IBlake2BConfig);
 end;
 
 class function THashFactory.TCrypto.CreateBlake2S(const AConfig: IBlake2SConfig;
@@ -1238,25 +1238,25 @@ end;
 class function THashFactory.TCrypto.CreateBlake2S_128: IHash;
 begin
   Result := THashFactory.TCrypto.CreateBlake2S
-    (TBlake2SConfig.Create(THashSize.hsHashSize128) as IBlake2SConfig);
+    (TBlake2SConfig.Create(THashSize.Size128) as IBlake2SConfig);
 end;
 
 class function THashFactory.TCrypto.CreateBlake2S_160: IHash;
 begin
   Result := THashFactory.TCrypto.CreateBlake2S
-    (TBlake2SConfig.Create(THashSize.hsHashSize160) as IBlake2SConfig);
+    (TBlake2SConfig.Create(THashSize.Size160) as IBlake2SConfig);
 end;
 
 class function THashFactory.TCrypto.CreateBlake2S_224: IHash;
 begin
   Result := THashFactory.TCrypto.CreateBlake2S
-    (TBlake2SConfig.Create(THashSize.hsHashSize224) as IBlake2SConfig);
+    (TBlake2SConfig.Create(THashSize.Size224) as IBlake2SConfig);
 end;
 
 class function THashFactory.TCrypto.CreateBlake2S_256: IHash;
 begin
   Result := THashFactory.TCrypto.CreateBlake2S
-    (TBlake2SConfig.Create(THashSize.hsHashSize256) as IBlake2SConfig);
+    (TBlake2SConfig.Create(THashSize.Size256) as IBlake2SConfig);
 end;
 
 class function THashFactory.TCrypto.CreateBlake2BP(AHashSize: Int32;
@@ -1274,7 +1274,7 @@ end;
 class function THashFactory.TCrypto.CreateBlake3_256
   (const AKey: THashLibByteArray): IHash;
 begin
-  Result := TBlake3.Create(THashSize.hsHashSize256, AKey);
+  Result := TBlake3.Create(THashSize.Size256, AKey);
 end;
 
 class function THashFactory.TCrypto.CreateSnefru(ASecurityLevel: Int32;
@@ -1284,7 +1284,7 @@ begin
     raise EArgumentHashLibException.CreateRes(@SInvalidSnefruLevel);
 
   case AHashSize of
-    THashSize.hsHashSize128, THashSize.hsHashSize256:
+    THashSize.Size128, THashSize.Size256:
       Result := TSnefru.Create(ASecurityLevel, AHashSize);
   else
     raise EArgumentHashLibException.CreateRes(@SInvalidSnefruHashSize);
@@ -1294,12 +1294,12 @@ end;
 
 class function THashFactory.TCrypto.CreateSnefru_8_128: IHash;
 begin
-  Result := CreateSnefru(8, THashSize.hsHashSize128);
+  Result := CreateSnefru(8, THashSize.Size128);
 end;
 
 class function THashFactory.TCrypto.CreateSnefru_8_256: IHash;
 begin
-  Result := CreateSnefru(8, THashSize.hsHashSize256);
+  Result := CreateSnefru(8, THashSize.Size256);
 end;
 
 class function THashFactory.TCrypto.CreateTiger_3_128: IHash;

--- a/HashLib/src/Base/HlpHashRounds.pas
+++ b/HashLib/src/Base/HlpHashRounds.pas
@@ -5,9 +5,7 @@ unit HlpHashRounds;
 interface
 
 type
-{$SCOPEDENUMS ON}
-  THashRounds = (hrRounds3 = 3, hrRounds4 = 4, hrRounds5 = 5, hrRounds8 = 8);
-{$SCOPEDENUMS OFF}
+  THashRounds = (Rounds3 = 3, Rounds4 = 4, Rounds5 = 5, Rounds8 = 8);
 
 implementation
 

--- a/HashLib/src/Base/HlpHashSize.pas
+++ b/HashLib/src/Base/HlpHashSize.pas
@@ -5,11 +5,8 @@ unit HlpHashSize;
 interface
 
 type
-{$SCOPEDENUMS ON}
-  THashSize = (hsHashSize128 = 16, hsHashSize160 = 20, hsHashSize192 = 24,
-    hsHashSize224 = 28, hsHashSize256 = 32, hsHashSize288 = 36,
-    hsHashSize384 = 48, hsHashSize512 = 64);
-{$SCOPEDENUMS OFF}
+  THashSize = (Size128 = 16, Size160 = 20, Size192 = 24, Size224 = 28,
+    Size256 = 32, Size288 = 36, Size384 = 48, Size512 = 64);
 
 implementation
 

--- a/HashLib/src/Crypto/Blake2BParams/HlpBlake2BParams.pas
+++ b/HashLib/src/Crypto/Blake2BParams/HlpBlake2BParams.pas
@@ -64,7 +64,7 @@ type
     procedure SetHashSize(AValue: Int32); inline;
 
   public
-    constructor Create(AHashSize: THashSize = THashSize.hsHashSize512);
+    constructor Create(AHashSize: THashSize = THashSize.Size512);
       overload;
     constructor Create(AHashSize: Int32); overload;
     destructor Destroy; override;

--- a/HashLib/src/Crypto/Blake2SParams/HlpBlake2SParams.pas
+++ b/HashLib/src/Crypto/Blake2SParams/HlpBlake2SParams.pas
@@ -64,7 +64,7 @@ type
     procedure SetHashSize(AValue: Int32); inline;
 
   public
-    constructor Create(AHashSize: THashSize = THashSize.hsHashSize256);
+    constructor Create(AHashSize: THashSize = THashSize.Size256);
       overload;
     constructor Create(AHashSize: Int32); overload;
     destructor Destroy; override;

--- a/HashLib/src/Crypto/HlpBlake3.pas
+++ b/HashLib/src/Crypto/HlpBlake3.pas
@@ -177,7 +177,7 @@ type
       AKeyWords: PCardinal; AFlags: UInt32);
 
   public
-    constructor Create(AHashSize: THashSize = THashSize.hsHashSize256;
+    constructor Create(AHashSize: THashSize = THashSize.Size256;
       const AKey: THashLibByteArray = nil); overload;
     procedure Initialize; override;
     procedure TransformBytes(const AData: THashLibByteArray;

--- a/HashLib/src/Crypto/HlpGost.pas
+++ b/HashLib/src/Crypto/HlpGost.pas
@@ -15,12 +15,10 @@ uses
 
 type
 
-{$SCOPEDENUMS ON}
-  TGostSBox = (gsbTestParamSet, gsbCryptoProParamSet);
-{$SCOPEDENUMS OFF}
-
   TGost = class sealed(TBlockHash, ICryptoNotBuildIn, ITransformBlock)
 
+  type
+    TSBoxType = (TestParamSet, CryptoProParamSet);
   strict private
 
     class var
@@ -32,7 +30,7 @@ type
   var
     FState, FHash: THashLibUInt32Array;
     FSBox1, FSBox2, FSBox3, FSBox4: THashLibUInt32Array;
-    FSBoxType: TGostSBox;
+    FSBoxType: TSBoxType;
 
     procedure Compress(APtr: PCardinal);
     class procedure ComputeSBoxes(const ASBox: THashLibMatrixUInt32Array;
@@ -46,7 +44,7 @@ type
       AIndex: Int32); override;
 
   public
-    constructor Create(ASBoxType: TGostSBox = TGostSBox.gsbTestParamSet);
+    constructor Create(ASBoxType: TSBoxType = TSBoxType.TestParamSet);
     procedure Initialize(); override;
     function Clone(): IHash; override;
 
@@ -378,21 +376,21 @@ begin
   end;
 end;
 
-constructor TGost.Create(ASBoxType: TGostSBox);
+constructor TGost.Create(ASBoxType: TGost.TSBoxType);
 begin
   inherited Create(32, 32);
   System.SetLength(FState, 8);
   System.SetLength(FHash, 8);
   FSBoxType := ASBoxType;
   case ASBoxType of
-    TGostSBox.gsbTestParamSet:
+    TGost.TSBoxType.TestParamSet:
       begin
         FSBox1 := FSBox1_Test;
         FSBox2 := FSBox2_Test;
         FSBox3 := FSBox3_Test;
         FSBox4 := FSBox4_Test;
       end;
-    TGostSBox.gsbCryptoProParamSet:
+    TGost.TSBoxType.CryptoProParamSet:
       begin
         FSBox1 := FSBox1_CryptoPro;
         FSBox2 := FSBox2_CryptoPro;

--- a/HashLib/src/Crypto/HlpHaval.pas
+++ b/HashLib/src/Crypto/HlpHaval.pas
@@ -376,7 +376,7 @@ end;
 
 constructor THaval3.Create(AHashSize: THashSize);
 begin
-  inherited Create(THashRounds.hrRounds3, AHashSize);
+  inherited Create(THashRounds.Rounds3, AHashSize);
 end;
 
 procedure THaval3.TransformBlock(AData: PByte; ADataLength: Int32;
@@ -796,7 +796,7 @@ end;
 
 constructor THaval4.Create(AHashSize: THashSize);
 begin
-  inherited Create(THashRounds.hrRounds4, AHashSize);
+  inherited Create(THashRounds.Rounds4, AHashSize);
 end;
 
 procedure THaval4.TransformBlock(AData: PByte; ADataLength: Int32;
@@ -1376,7 +1376,7 @@ end;
 
 constructor THaval5.Create(AHashSize: THashSize);
 begin
-  inherited Create(THashRounds.hrRounds5, AHashSize);
+  inherited Create(THashRounds.Rounds5, AHashSize);
 end;
 
 procedure THaval5.TransformBlock(AData: PByte; ADataLength: Int32;
@@ -2095,7 +2095,7 @@ end;
 
 constructor THaval_3_128.Create;
 begin
-  inherited Create(THashSize.hsHashSize128);
+  inherited Create(THashSize.Size128);
 end;
 
 { THaval_4_128 }
@@ -2114,7 +2114,7 @@ end;
 
 constructor THaval_4_128.Create;
 begin
-  inherited Create(THashSize.hsHashSize128);
+  inherited Create(THashSize.Size128);
 end;
 
 { THaval_5_128 }
@@ -2133,7 +2133,7 @@ end;
 
 constructor THaval_5_128.Create;
 begin
-  inherited Create(THashSize.hsHashSize128);
+  inherited Create(THashSize.Size128);
 end;
 
 { THaval_3_160 }
@@ -2152,7 +2152,7 @@ end;
 
 constructor THaval_3_160.Create;
 begin
-  inherited Create(THashSize.hsHashSize160);
+  inherited Create(THashSize.Size160);
 end;
 
 { THaval_4_160 }
@@ -2171,7 +2171,7 @@ end;
 
 constructor THaval_4_160.Create;
 begin
-  inherited Create(THashSize.hsHashSize160);
+  inherited Create(THashSize.Size160);
 end;
 
 { THaval_5_160 }
@@ -2190,7 +2190,7 @@ end;
 
 constructor THaval_5_160.Create;
 begin
-  inherited Create(THashSize.hsHashSize160);
+  inherited Create(THashSize.Size160);
 end;
 
 { THaval_3_192 }
@@ -2209,7 +2209,7 @@ end;
 
 constructor THaval_3_192.Create;
 begin
-  inherited Create(THashSize.hsHashSize192);
+  inherited Create(THashSize.Size192);
 end;
 
 { THaval_4_192 }
@@ -2228,7 +2228,7 @@ end;
 
 constructor THaval_4_192.Create;
 begin
-  inherited Create(THashSize.hsHashSize192);
+  inherited Create(THashSize.Size192);
 end;
 
 { THaval_5_192 }
@@ -2247,7 +2247,7 @@ end;
 
 constructor THaval_5_192.Create;
 begin
-  inherited Create(THashSize.hsHashSize192);
+  inherited Create(THashSize.Size192);
 end;
 
 { THaval_3_224 }
@@ -2266,7 +2266,7 @@ end;
 
 constructor THaval_3_224.Create;
 begin
-  inherited Create(THashSize.hsHashSize224);
+  inherited Create(THashSize.Size224);
 end;
 
 { THaval_4_224 }
@@ -2285,7 +2285,7 @@ end;
 
 constructor THaval_4_224.Create;
 begin
-  inherited Create(THashSize.hsHashSize224);
+  inherited Create(THashSize.Size224);
 end;
 
 { THaval_5_224 }
@@ -2304,7 +2304,7 @@ end;
 
 constructor THaval_5_224.Create;
 begin
-  inherited Create(THashSize.hsHashSize224);
+  inherited Create(THashSize.Size224);
 end;
 
 { THaval_3_256 }
@@ -2323,7 +2323,7 @@ end;
 
 constructor THaval_3_256.Create;
 begin
-  inherited Create(THashSize.hsHashSize256);
+  inherited Create(THashSize.Size256);
 end;
 
 { THaval_4_256 }
@@ -2342,7 +2342,7 @@ end;
 
 constructor THaval_4_256.Create;
 begin
-  inherited Create(THashSize.hsHashSize256);
+  inherited Create(THashSize.Size256);
 end;
 
 { THaval_5_256 }
@@ -2361,7 +2361,7 @@ end;
 
 constructor THaval_5_256.Create;
 begin
-  inherited Create(THashSize.hsHashSize256);
+  inherited Create(THashSize.Size256);
 end;
 
 end.

--- a/HashLib/src/Crypto/HlpSHA3.pas
+++ b/HashLib/src/Crypto/HlpSHA3.pas
@@ -29,9 +29,7 @@ type
   TSHA3 = class abstract(TBlockHash, ICryptoNotBuildIn, ITransformBlock)
 
   type
-{$SCOPEDENUMS ON}
-    THashMode = (hmKeccak = $1, hmCShake = $4, hmSHA3 = $6, hmShake = $1F);
-{$SCOPEDENUMS OFF}
+    THashMode = (Keccak = $1, CShake = $4, SHA3 = $6, Shake = $1F);
   strict protected
   var
     FState: THashLibUInt64Array;
@@ -363,7 +361,7 @@ implementation
 
 function TSHA3.GetHashMode(): TSHA3.THashMode;
 begin
-  Result := TSHA3.THashMode.hmSHA3;
+  Result := TSHA3.THashMode.SHA3;
 end;
 
 constructor TSHA3.Create(AHashSize: THashSize);
@@ -465,7 +463,7 @@ end;
 
 constructor TSHA3_224.Create;
 begin
-  inherited Create(THashSize.hsHashSize224);
+  inherited Create(THashSize.Size224);
 end;
 
 { TSHA3_256 }
@@ -484,7 +482,7 @@ end;
 
 constructor TSHA3_256.Create;
 begin
-  inherited Create(THashSize.hsHashSize256);
+  inherited Create(THashSize.Size256);
 end;
 
 { TSHA3_384 }
@@ -503,7 +501,7 @@ end;
 
 constructor TSHA3_384.Create;
 begin
-  inherited Create(THashSize.hsHashSize384);
+  inherited Create(THashSize.Size384);
 end;
 
 { TSHA3_512 }
@@ -522,7 +520,7 @@ end;
 
 constructor TSHA3_512.Create;
 begin
-  inherited Create(THashSize.hsHashSize512);
+  inherited Create(THashSize.Size512);
 end;
 
 { TKeccak_224 }
@@ -541,7 +539,7 @@ end;
 
 constructor TKeccak_224.Create;
 begin
-  inherited Create(THashSize.hsHashSize224);
+  inherited Create(THashSize.Size224);
 end;
 
 { TKeccak_256 }
@@ -560,7 +558,7 @@ end;
 
 constructor TKeccak_256.Create;
 begin
-  inherited Create(THashSize.hsHashSize256);
+  inherited Create(THashSize.Size256);
 end;
 
 { TKeccak_288 }
@@ -579,7 +577,7 @@ end;
 
 constructor TKeccak_288.Create;
 begin
-  inherited Create(THashSize.hsHashSize288);
+  inherited Create(THashSize.Size288);
 end;
 
 { TKeccak_384 }
@@ -598,7 +596,7 @@ end;
 
 constructor TKeccak_384.Create;
 begin
-  inherited Create(THashSize.hsHashSize384);
+  inherited Create(THashSize.Size384);
 end;
 
 { TKeccak_512 }
@@ -617,14 +615,14 @@ end;
 
 constructor TKeccak_512.Create;
 begin
-  inherited Create(THashSize.hsHashSize512);
+  inherited Create(THashSize.Size512);
 end;
 
 { TShake }
 
 function TShake.GetHashMode(): TSHA3.THashMode;
 begin
-  Result := TSHA3.THashMode.hmShake;
+  Result := TSHA3.THashMode.Shake;
 end;
 
 function TShake.SetXOFSizeInBitsInternal(AXofSizeInBits: UInt64): IXOF;
@@ -790,7 +788,7 @@ end;
 
 constructor TShake_128.Create;
 begin
-  inherited Create(THashSize.hsHashSize128);
+  inherited Create(THashSize.Size128);
 end;
 
 { TShake_256 }
@@ -822,7 +820,7 @@ end;
 
 constructor TShake_256.Create;
 begin
-  inherited Create(THashSize.hsHashSize256);
+  inherited Create(THashSize.Size256);
 end;
 
 { TCShake }
@@ -831,11 +829,11 @@ function TCShake.GetHashMode(): TSHA3.THashMode;
 begin
   if (System.Length(FN) = 0) and (System.Length(FS) = 0) then
   begin
-    Result := TSHA3.THashMode.hmShake;
+    Result := TSHA3.THashMode.Shake;
   end
   else
   begin
-    Result := TSHA3.THashMode.hmCShake;
+    Result := TSHA3.THashMode.CShake;
   end;
 end;
 
@@ -970,7 +968,7 @@ end;
 
 constructor TCShake_128.Create(const AN, &AS: THashLibByteArray);
 begin
-  inherited Create(THashSize.hsHashSize128, AN, &AS);
+  inherited Create(THashSize.Size128, AN, &AS);
 end;
 
 { TCShake_256 }
@@ -1004,7 +1002,7 @@ end;
 
 constructor TCShake_256.Create(const AN, &AS: THashLibByteArray);
 begin
-  inherited Create(THashSize.hsHashSize256, AN, &AS);
+  inherited Create(THashSize.Size256, AN, &AS);
 end;
 
 { TKMACNotBuildInAdapter }
@@ -1130,7 +1128,7 @@ end;
 constructor TKMAC128.Create(const AHash: IHash;
   const AKMACKey: THashLibByteArray; AOutputLengthInBits: UInt64);
 begin
-  inherited Create(Int32(THashSize.hsHashSize128));
+  inherited Create(Int32(THashSize.Size128));
   SetKey(AKMACKey);
   FHash := AHash;
   HashInstanceAsXof.XOFSizeInBits := AOutputLengthInBits;
@@ -1183,7 +1181,7 @@ end;
 constructor TKMAC128XOF.Create(const AHash: IHash;
   const AKMACKey: THashLibByteArray);
 begin
-  inherited Create(Int32(THashSize.hsHashSize128));
+  inherited Create(Int32(THashSize.Size128));
   SetKey(AKMACKey);
   FHash := AHash;
 end;
@@ -1227,7 +1225,7 @@ end;
 constructor TKMAC256.Create(const AHash: IHash;
   const AKMACKey: THashLibByteArray; AOutputLengthInBits: UInt64);
 begin
-  inherited Create(Int32(THashSize.hsHashSize256));
+  inherited Create(Int32(THashSize.Size256));
   SetKey(AKMACKey);
   FHash := AHash;
   HashInstanceAsXof.XOFSizeInBits := AOutputLengthInBits;
@@ -1280,7 +1278,7 @@ end;
 constructor TKMAC256XOF.Create(const AHash: IHash;
   const AKMACKey: THashLibByteArray);
 begin
-  inherited Create(Int32(THashSize.hsHashSize256));
+  inherited Create(Int32(THashSize.Size256));
   SetKey(AKMACKey);
   FHash := AHash;
 end;
@@ -1306,7 +1304,7 @@ end;
 
 function TKeccak.GetHashMode(): TSHA3.THashMode;
 begin
-  Result := TSHA3.THashMode.hmKeccak;
+  Result := TSHA3.THashMode.Keccak;
 end;
 
 end.

--- a/HashLib/src/Crypto/HlpSnefru.pas
+++ b/HashLib/src/Crypto/HlpSnefru.pas
@@ -70,9 +70,9 @@ function TSnefru.GetSnefruHashSize(AHashSize: Int32): THashSize;
 begin
   case AHashSize of
     16:
-      Result := THashSize.hsHashSize128;
+      Result := THashSize.Size128;
     32:
-      Result := THashSize.hsHashSize256
+      Result := THashSize.Size256
   else
     begin
       raise EArgumentInvalidHashLibException.CreateResFmt(@SInvalidHashSize,

--- a/HashLib/src/Crypto/HlpTiger.pas
+++ b/HashLib/src/Crypto/HlpTiger.pas
@@ -621,13 +621,13 @@ function TTiger.GetHashRound(AHashRound: Int32): THashRounds;
 begin
   case AHashRound of
     3:
-      Result := THashRounds.hrRounds3;
+      Result := THashRounds.Rounds3;
     4:
-      Result := THashRounds.hrRounds4;
+      Result := THashRounds.Rounds4;
     5:
-      Result := THashRounds.hrRounds5;
+      Result := THashRounds.Rounds5;
     8:
-      Result := THashRounds.hrRounds8
+      Result := THashRounds.Rounds8
   else
     begin
       raise EArgumentInvalidHashLibException.CreateResFmt(@SInvalidHashRound,
@@ -1014,17 +1014,17 @@ end;
 
 constructor TTiger_128.CreateRound3;
 begin
-  inherited Create(16, THashRounds.hrRounds3);
+  inherited Create(16, THashRounds.Rounds3);
 end;
 
 constructor TTiger_128.CreateRound4;
 begin
-  inherited Create(16, THashRounds.hrRounds4);
+  inherited Create(16, THashRounds.Rounds4);
 end;
 
 constructor TTiger_128.CreateRound5;
 begin
-  inherited Create(16, THashRounds.hrRounds5);
+  inherited Create(16, THashRounds.Rounds5);
 end;
 
 { TTiger_160 }
@@ -1043,17 +1043,17 @@ end;
 
 constructor TTiger_160.CreateRound3;
 begin
-  inherited Create(20, THashRounds.hrRounds3);
+  inherited Create(20, THashRounds.Rounds3);
 end;
 
 constructor TTiger_160.CreateRound4;
 begin
-  inherited Create(20, THashRounds.hrRounds4);
+  inherited Create(20, THashRounds.Rounds4);
 end;
 
 constructor TTiger_160.CreateRound5;
 begin
-  inherited Create(20, THashRounds.hrRounds5);
+  inherited Create(20, THashRounds.Rounds5);
 end;
 
 { TTiger_192 }
@@ -1072,17 +1072,17 @@ end;
 
 constructor TTiger_192.CreateRound3;
 begin
-  inherited Create(24, THashRounds.hrRounds3);
+  inherited Create(24, THashRounds.Rounds3);
 end;
 
 constructor TTiger_192.CreateRound4;
 begin
-  inherited Create(24, THashRounds.hrRounds4);
+  inherited Create(24, THashRounds.Rounds4);
 end;
 
 constructor TTiger_192.CreateRound5;
 begin
-  inherited Create(24, THashRounds.hrRounds5);
+  inherited Create(24, THashRounds.Rounds5);
 end;
 
 { TTiger_Base }

--- a/HashLib/src/Crypto/HlpTiger2.pas
+++ b/HashLib/src/Crypto/HlpTiger2.pas
@@ -621,13 +621,13 @@ function TTiger2.GetHashRound(AHashRound: Int32): THashRounds;
 begin
   case AHashRound of
     3:
-      Result := THashRounds.hrRounds3;
+      Result := THashRounds.Rounds3;
     4:
-      Result := THashRounds.hrRounds4;
+      Result := THashRounds.Rounds4;
     5:
-      Result := THashRounds.hrRounds5;
+      Result := THashRounds.Rounds5;
     8:
-      Result := THashRounds.hrRounds8
+      Result := THashRounds.Rounds8
   else
     begin
       raise EArgumentInvalidHashLibException.CreateResFmt(@SInvalidHashRound,
@@ -1014,17 +1014,17 @@ end;
 
 constructor TTiger2_128.CreateRound3;
 begin
-  inherited Create(16, THashRounds.hrRounds3);
+  inherited Create(16, THashRounds.Rounds3);
 end;
 
 constructor TTiger2_128.CreateRound4;
 begin
-  inherited Create(16, THashRounds.hrRounds4);
+  inherited Create(16, THashRounds.Rounds4);
 end;
 
 constructor TTiger2_128.CreateRound5;
 begin
-  inherited Create(16, THashRounds.hrRounds5);
+  inherited Create(16, THashRounds.Rounds5);
 end;
 
 { TTiger2_160 }
@@ -1043,17 +1043,17 @@ end;
 
 constructor TTiger2_160.CreateRound3;
 begin
-  inherited Create(20, THashRounds.hrRounds3);
+  inherited Create(20, THashRounds.Rounds3);
 end;
 
 constructor TTiger2_160.CreateRound4;
 begin
-  inherited Create(20, THashRounds.hrRounds4);
+  inherited Create(20, THashRounds.Rounds4);
 end;
 
 constructor TTiger2_160.CreateRound5;
 begin
-  inherited Create(20, THashRounds.hrRounds5);
+  inherited Create(20, THashRounds.Rounds5);
 end;
 
 { TTiger2_192 }
@@ -1072,17 +1072,17 @@ end;
 
 constructor TTiger2_192.CreateRound3;
 begin
-  inherited Create(24, THashRounds.hrRounds3);
+  inherited Create(24, THashRounds.Rounds3);
 end;
 
 constructor TTiger2_192.CreateRound4;
 begin
-  inherited Create(24, THashRounds.hrRounds4);
+  inherited Create(24, THashRounds.Rounds4);
 end;
 
 constructor TTiger2_192.CreateRound5;
 begin
-  inherited Create(24, THashRounds.hrRounds5);
+  inherited Create(24, THashRounds.Rounds5);
 end;
 
 { TTiger2_Base }

--- a/HashLib/src/KDF/HlpArgon2TypeAndVersion.pas
+++ b/HashLib/src/KDF/HlpArgon2TypeAndVersion.pas
@@ -5,10 +5,8 @@ unit HlpArgon2TypeAndVersion;
 interface
 
 type
-{$SCOPEDENUMS ON}
-  TArgon2Type = (a2tARGON2_d = $00, a2tARGON2_i = $01, a2tARGON2_id = $02);
-  TArgon2Version = (a2vARGON2_VERSION_10 = $10, a2vARGON2_VERSION_13 = $13);
-{$SCOPEDENUMS OFF}
+  TArgon2Type = (TypeD = $00, TypeI = $01, TypeID = $02);
+  TArgon2Version = (Version10 = $10, Version13 = $13);
 
 implementation
 

--- a/HashLib/src/KDF/HlpPBKDF_Argon2NotBuildInAdapter.pas
+++ b/HashLib/src/KDF/HlpPBKDF_Argon2NotBuildInAdapter.pas
@@ -42,8 +42,8 @@ type
     DefaultIterations = Int32(3);
     DefaultMemoryCost = Int32(12);
     DefaultLanes = Int32(1);
-    DefaultType: TArgon2Type = TArgon2Type.a2tARGON2_i;
-    DefaultVersion: TArgon2Version = TArgon2Version.a2vARGON2_VERSION_13;
+    DefaultType: TArgon2Type = TArgon2Type.TypeI;
+    DefaultVersion: TArgon2Version = TArgon2Version.Version13;
 
   var
     FSalt, FSecret, FAdditional: THashLibByteArray;
@@ -664,7 +664,7 @@ end;
 
 constructor TArgon2iParametersBuilder.Create;
 begin
-  inherited Create(TArgon2Type.a2tARGON2_i);
+  inherited Create(TArgon2Type.TypeI);
 end;
 
 class function TArgon2iParametersBuilder.Builder: IArgon2ParametersBuilder;
@@ -676,7 +676,7 @@ end;
 
 constructor TArgon2dParametersBuilder.Create;
 begin
-  inherited Create(TArgon2Type.a2tARGON2_d);
+  inherited Create(TArgon2Type.TypeD);
 end;
 
 class function TArgon2dParametersBuilder.Builder: IArgon2ParametersBuilder;
@@ -688,7 +688,7 @@ end;
 
 constructor TArgon2idParametersBuilder.Create;
 begin
-  inherited Create(TArgon2Type.a2tARGON2_id);
+  inherited Create(TArgon2Type.TypeID);
 end;
 
 class function TArgon2idParametersBuilder.Builder: IArgon2ParametersBuilder;
@@ -968,8 +968,8 @@ end;
 function TPBKDF_Argon2NotBuildInAdapter.IsDataIndependentAddressing
   (const APosition: TPosition): Boolean;
 begin
-  Result := (FParameters.&Type = TArgon2Type.a2tARGON2_i) or
-    ((FParameters.&Type = TArgon2Type.a2tARGON2_id) and (APosition.Pass = 0)
+  Result := (FParameters.&Type = TArgon2Type.TypeI) or
+    ((FParameters.&Type = TArgon2Type.TypeID) and (APosition.Pass = 0)
     and (APosition.Slice < (Argon2SyncPoints div 2)));
 end;
 
@@ -1102,7 +1102,7 @@ function TPBKDF_Argon2NotBuildInAdapter.IsWithXor(const APosition
   : TPosition): Boolean;
 begin
   Result := not((APosition.Pass = 0) or
-    (FParameters.Version = TArgon2Version.a2vARGON2_VERSION_10));
+    (FParameters.Version = TArgon2Version.Version10));
 end;
 
 function TPBKDF_Argon2NotBuildInAdapter.GetPrevOffset(ACurrentOffset


### PR DESCRIPTION
…ost, Argon2)

BREAKING CHANGE: many qualified enum identifiers changed; update call sites.

- THashSize: Size128…Size512 (byte counts unchanged).
- THashRounds: Rounds3…Rounds8 (values unchanged).
- TSHA3.THashMode: Keccak, CShake, SHA3, Shake (numeric tags unchanged).
- TGost.TSBoxType: TestParamSet, CryptoProParamSet (nested under TGost).
- TArgon2Type: TypeD, TypeI, TypeID ($00/$01/$02).
- TArgon2Version: Version10, Version13 ($10/$13).
- Drop per-unit {$SCOPEDENUMS ON/OFF}; rely on HashLib.inc.

Argon2/GOST factory and tests updated. Any external code using old enumerator names must be migrated; integer values for sized enums are preserved where set.