### PR TITLE
refactor: move dynamic import resolution to unit initialization

### DIFF
--- a/HashLib/src/Utils/HlpArmHwCapProvider.pas
+++ b/HashLib/src/Utils/HlpArmHwCapProvider.pas
@@ -92,10 +92,9 @@ type
   strict private
   class var
     FGetAuxVal: TGetAuxValFunc;
-    FResolved: Boolean;
 
-  strict private
-    class procedure ResolveOnce(); static;
+  private
+    class procedure ResolveDynamicImports(); static;
 
   public
     class function GetHwCap(): UInt64; static;
@@ -110,10 +109,9 @@ type
   strict private
   class var
     FElfAuxInfo: TElfAuxInfoFunc;
-    FResolved: Boolean;
 
-  strict private
-    class procedure ResolveOnce(); static;
+  private
+    class procedure ResolveDynamicImports(); static;
 
   public
     class function GetHwCap(): UInt64; static;
@@ -139,15 +137,11 @@ implementation
 
 {$IF DEFINED(HASHLIB_LINUX) OR DEFINED(HASHLIB_ANDROID)}
 
-class procedure TArmHwCapProvider.ResolveOnce();
+class procedure TArmHwCapProvider.ResolveDynamicImports();
 var
   LHandle: Pointer;
 begin
-  if FResolved then
-    Exit;
-
   FGetAuxVal := nil;
-  FResolved := True;
 
   LHandle := dlopen(nil, RTLD_NOW);
   if LHandle = nil then
@@ -163,7 +157,6 @@ end;
 
 class function TArmHwCapProvider.GetHwCap(): UInt64;
 begin
-  ResolveOnce();
   if System.Assigned(FGetAuxVal) then
     Result := FGetAuxVal(AT_HWCAP)
   else
@@ -172,7 +165,6 @@ end;
 
 class function TArmHwCapProvider.GetHwCap2(): UInt64;
 begin
-  ResolveOnce();
   if System.Assigned(FGetAuxVal) then
     Result := FGetAuxVal(AT_HWCAP2)
   else
@@ -185,15 +177,11 @@ end;
 
 {$IF DEFINED(HASHLIB_BSD)}
 
-class procedure TArmHwCapProvider.ResolveOnce();
+class procedure TArmHwCapProvider.ResolveDynamicImports();
 var
   LHandle: Pointer;
 begin
-  if FResolved then
-    Exit;
-
   FElfAuxInfo := nil;
-  FResolved := True;
 
   LHandle := dlopen(nil, RTLD_NOW);
   if LHandle = nil then
@@ -216,7 +204,6 @@ class function TArmHwCapProvider.GetHwCap(): UInt64;
 var
   LValue: UInt64;
 begin
-  ResolveOnce();
   if System.Assigned(FElfAuxInfo) then
   begin
     LValue := 0;
@@ -233,7 +220,6 @@ class function TArmHwCapProvider.GetHwCap2(): UInt64;
 var
   LValue: UInt64;
 begin
-  ResolveOnce();
   if System.Assigned(FElfAuxInfo) then
   begin
     LValue := 0;
@@ -258,6 +244,11 @@ begin
 end;
 
 {$IFEND} // HASHLIB_MSWINDOWS
+
+{$IF DEFINED(HASHLIB_LINUX) OR DEFINED(HASHLIB_ANDROID) OR DEFINED(HASHLIB_BSD)}
+initialization
+  TArmHwCapProvider.ResolveDynamicImports;
+{$IFEND}
 
 {$IFEND} // HASHLIB_ARM
 

--- a/HashLib/src/Utils/HlpDarwinSysCtl.pas
+++ b/HashLib/src/Utils/HlpDarwinSysCtl.pas
@@ -31,10 +31,9 @@ type
   strict private
   class var
     FSysCtlByName: TSysCtlByNameFunc;
-    FResolved: Boolean;
 
-  strict private
-    class procedure ResolveOnce(); static;
+  private
+    class procedure ResolveDynamicImports(); static;
 
     /// <summary>
     /// Queries a single sysctl key. Returns True if the key exists and
@@ -63,15 +62,11 @@ implementation
 
 { TDarwinSysCtl }
 
-class procedure TDarwinSysCtl.ResolveOnce();
+class procedure TDarwinSysCtl.ResolveDynamicImports();
 var
   LHandle: Pointer;
 begin
-  if FResolved then
-    Exit;
-
   FSysCtlByName := nil;
-  FResolved := True;
 
   LHandle := dlopen(nil, RTLD_NOW);
   if LHandle = nil then
@@ -107,8 +102,6 @@ end;
 class function TDarwinSysCtl.HasFeature(const AModernName: PAnsiChar;
   const ALegacyName: PAnsiChar): Boolean;
 begin
-  ResolveOnce();
-
   if not System.Assigned(FSysCtlByName) then
   begin
     Result := False;
@@ -122,6 +115,9 @@ begin
   if (not Result) and (ALegacyName <> nil) then
     Result := QueryKey(ALegacyName);
 end;
+
+initialization
+  TDarwinSysCtl.ResolveDynamicImports;
 
 {$IFEND} // HASHLIB_MACOS OR HASHLIB_IOS
 {$IFEND} // HASHLIB_ARM


### PR DESCRIPTION
## Summary

Move dynamic library symbol resolution (`dlopen`/`dlsym`) from lazy
per-call resolution to one-time unit initialization for ARM hardware
capability detection on Linux, Android, BSD, and macOS (Darwin).

## Changes

### HlpArmHwCapProvider.pas (Linux/Android and BSD)

- Renamed `ResolveOnce` to `ResolveDynamicImports` and removed the
  manual `FResolved` boolean guard, since the initialization section
  guarantees single execution.
- Removed `ResolveOnce` calls from `GetHwCap` and `GetHwCap2` — the
  function pointers are already resolved by the time any caller can
  reach them.
- Added an `initialization` section that calls
  `ResolveDynamicImports` at unit load time.
- Relaxed visibility from `strict private` to `private` so the
  initialization section can access the method.

### HlpDarwinSysCtl.pas (macOS/iOS)

- Same refactor: renamed `ResolveOnce` to `ResolveDynamicImports`,
  removed the `FResolved` guard, removed the call from `HasFeature`,
  and moved resolution to an `initialization` section.

## Rationale

The previous pattern resolved imports lazily on first use with a
boolean guard. This worked but added a branch to every call of
`GetHwCap`, `GetHwCap2`, and `HasFeature`. Since these function
pointers never change after resolution, performing the `dlopen`/`dlsym`
once at unit initialization is simpler, removes the redundant flag
field, and eliminates repeated nil-check overhead on the hot path.