### PR TITLE
feat(xof): add IXOFStream continuous-squeeze API across all XOFs

### DIFF
--- a/HashLib.Tests/src/CryptoTests.pas
+++ b/HashLib.Tests/src/CryptoTests.pas
@@ -739,6 +739,57 @@ type
 
   end;
 
+  // ----- Streaming XOF (IXOFStream / continuous squeeze) test cases ----- //
+
+type
+  TTestShake_128Stream = class(TXofStreamAlgorithmTestCase)
+  protected
+    procedure SetUp; override;
+    procedure TearDown; override;
+  end;
+
+type
+  TTestShake_256Stream = class(TXofStreamAlgorithmTestCase)
+  protected
+    procedure SetUp; override;
+    procedure TearDown; override;
+  end;
+
+type
+  TTestCShake_128Stream = class(TXofStreamAlgorithmTestCase)
+  protected
+    procedure SetUp; override;
+    procedure TearDown; override;
+  end;
+
+type
+  TTestCShake_256Stream = class(TXofStreamAlgorithmTestCase)
+  protected
+    procedure SetUp; override;
+    procedure TearDown; override;
+  end;
+
+type
+  TTestBlake2XSStream = class(TXofStreamAlgorithmTestCase)
+  protected
+    procedure SetUp; override;
+    procedure TearDown; override;
+  end;
+
+type
+  TTestBlake2XBStream = class(TXofStreamAlgorithmTestCase)
+  protected
+    procedure SetUp; override;
+    procedure TearDown; override;
+  end;
+
+type
+  TTestBlake3XOFStream = class(TXofStreamAlgorithmTestCase)
+  protected
+    procedure SetUp; override;
+    procedure TearDown; override;
+  end;
+
 type
   TTestKeccak_224 = class(TCryptoAlgorithmTestCase)
 
@@ -820,6 +871,8 @@ type
     procedure TestKMAC128XOFNISTSample1;
     procedure TestKMAC128XOFNISTSample2;
     procedure TestKMAC128XOFNISTSample3;
+    procedure TestKMAC128XOFMultiChunkConsistency;
+    procedure TestKMAC128XOFStreamMatchesSized;
 
   end;
 
@@ -844,6 +897,8 @@ type
     procedure TestKMAC256XOFNISTSample1;
     procedure TestKMAC256XOFNISTSample2;
     procedure TestKMAC256XOFNISTSample3;
+    procedure TestKMAC256XOFMultiChunkConsistency;
+    procedure TestKMAC256XOFStreamMatchesSized;
 
   end;
 
@@ -3390,6 +3445,124 @@ begin
   inherited;
 end;
 
+{ TTestShake_128Stream }
+
+procedure TTestShake_128Stream.SetUp;
+begin
+  inherited;
+  StreamInstance := THashFactory.TXOF.CreateShake_128Stream();
+  // SHAKE output is length-independent, so a sized reference matches the stream
+  ReferenceXof := THashFactory.TXOF.CreateShake_128(512 * 8) as IXOF;
+end;
+
+procedure TTestShake_128Stream.TearDown;
+begin
+  StreamInstance := nil;
+  ReferenceXof := nil;
+  inherited;
+end;
+
+{ TTestShake_256Stream }
+
+procedure TTestShake_256Stream.SetUp;
+begin
+  inherited;
+  StreamInstance := THashFactory.TXOF.CreateShake_256Stream();
+  ReferenceXof := THashFactory.TXOF.CreateShake_256(512 * 8) as IXOF;
+end;
+
+procedure TTestShake_256Stream.TearDown;
+begin
+  StreamInstance := nil;
+  ReferenceXof := nil;
+  inherited;
+end;
+
+{ TTestCShake_128Stream }
+
+procedure TTestCShake_128Stream.SetUp;
+begin
+  inherited;
+  StreamInstance := THashFactory.TXOF.CreateCShake_128Stream(nil, nil);
+  ReferenceXof := THashFactory.TXOF.CreateCShake_128(nil, nil, 512 * 8) as IXOF;
+end;
+
+procedure TTestCShake_128Stream.TearDown;
+begin
+  StreamInstance := nil;
+  ReferenceXof := nil;
+  inherited;
+end;
+
+{ TTestCShake_256Stream }
+
+procedure TTestCShake_256Stream.SetUp;
+begin
+  inherited;
+  StreamInstance := THashFactory.TXOF.CreateCShake_256Stream(nil, nil);
+  ReferenceXof := THashFactory.TXOF.CreateCShake_256(nil, nil, 512 * 8) as IXOF;
+end;
+
+procedure TTestCShake_256Stream.TearDown;
+begin
+  StreamInstance := nil;
+  ReferenceXof := nil;
+  inherited;
+end;
+
+{ TTestBlake2XSStream }
+
+procedure TTestBlake2XSStream.SetUp;
+begin
+  inherited;
+  StreamInstance := THashFactory.TXOF.CreateBlake2XSStream(nil);
+  // Blake2X output depends on the declared length, so the reference must also
+  // be in unknown-length (streaming) mode. The streaming instance already
+  // owns that mode, so view a fresh one through IXOF rather than re-deriving
+  // the magic sentinel here.
+  ReferenceXof := THashFactory.TXOF.CreateBlake2XSStream(nil) as IXOF;
+end;
+
+procedure TTestBlake2XSStream.TearDown;
+begin
+  StreamInstance := nil;
+  ReferenceXof := nil;
+  inherited;
+end;
+
+{ TTestBlake2XBStream }
+
+procedure TTestBlake2XBStream.SetUp;
+begin
+  inherited;
+  StreamInstance := THashFactory.TXOF.CreateBlake2XBStream(nil);
+  // unknown-length (streaming) mode reference, viewed through IXOF
+  ReferenceXof := THashFactory.TXOF.CreateBlake2XBStream(nil) as IXOF;
+end;
+
+procedure TTestBlake2XBStream.TearDown;
+begin
+  StreamInstance := nil;
+  ReferenceXof := nil;
+  inherited;
+end;
+
+{ TTestBlake3XOFStream }
+
+procedure TTestBlake3XOFStream.SetUp;
+begin
+  inherited;
+  StreamInstance := THashFactory.TXOF.CreateBlake3XOFStream(nil);
+  ReferenceXof := THashFactory.TXOF.CreateBlake3XOF(nil, 512 * 8) as IXOF;
+end;
+
+procedure TTestBlake3XOFStream.TearDown;
+begin
+  StreamInstance := nil;
+  ReferenceXof := nil;
+  inherited;
+end;
+
 procedure TTestBlake3XOF.TestCheckTestVectors;
 var
   LIdx: Int32;
@@ -3648,6 +3821,104 @@ begin
     OutputSizeInBits, True);
 end;
 
+procedure TTestKMAC128.TestKMAC128XOFMultiChunkConsistency;
+const
+  CTotal = Int32(512);
+  CChunks: array [0 .. 4] of Int32 = (1, 7, 13, 64, 100);
+var
+  LKey, LCustomization, LData, LSingle, LChunked: TBytes;
+  LXof1, LXof2: IXOF;
+  LOffset, LChunkSize, LIdx: Int32;
+begin
+  LKey := TConverters.ConvertHexStringToBytes(RawKeyInHex);
+  LCustomization := TConverters.ConvertStringToBytes(CustomizationMessage,
+    TEncoding.UTF8);
+  LData := TConverters.ConvertHexStringToBytes(FData);
+
+  // single-call DoOutput reference
+  LXof1 := THashFactory.TXOF.CreateKMAC128XOF(LKey, LCustomization,
+    UInt64(CTotal) * 8) as IXOF;
+  LXof1.Initialize;
+  LXof1.TransformBytes(LData);
+  LSingle := nil;
+  System.SetLength(LSingle, CTotal);
+  LXof1.DoOutput(LSingle, 0, CTotal);
+
+  // multi-chunk (3+ uneven) DoOutput: regression gate ensuring RightEncode is
+  // appended exactly once across successive output calls
+  LXof2 := THashFactory.TXOF.CreateKMAC128XOF(LKey, LCustomization,
+    UInt64(CTotal) * 8) as IXOF;
+  LXof2.Initialize;
+  LXof2.TransformBytes(LData);
+  LChunked := nil;
+  System.SetLength(LChunked, CTotal);
+  LOffset := 0;
+  LIdx := 0;
+  while LOffset < CTotal do
+  begin
+    LChunkSize := CChunks[LIdx mod System.Length(CChunks)];
+    if LChunkSize > (CTotal - LOffset) then
+    begin
+      LChunkSize := CTotal - LOffset;
+    end;
+    LXof2.DoOutput(LChunked, LOffset, LChunkSize);
+    System.Inc(LOffset, LChunkSize);
+    System.Inc(LIdx);
+  end;
+
+  CheckTrue(AreEqual(LSingle, LChunked),
+    'KMAC128XOF multi-chunk DoOutput does not match single DoOutput ' +
+    '(RightEncode-once regression)');
+end;
+
+procedure TTestKMAC128.TestKMAC128XOFStreamMatchesSized;
+const
+  CTotal = Int32(512);
+  CChunks: array [0 .. 4] of Int32 = (1, 7, 13, 64, 100);
+var
+  LKey, LCustomization, LData, LSized, LStreamed: TBytes;
+  LSizedXof: IXOF;
+  LStream: IXOFStream;
+  LOffset, LChunkSize, LIdx: Int32;
+begin
+  LKey := TConverters.ConvertHexStringToBytes(RawKeyInHex);
+  LCustomization := TConverters.ConvertStringToBytes(CustomizationMessage,
+    TEncoding.UTF8);
+  LData := TConverters.ConvertHexStringToBytes(FData);
+
+  // sized KMAC-XOF reference (already NIST-verified via the samples above)
+  LSizedXof := THashFactory.TXOF.CreateKMAC128XOF(LKey, LCustomization,
+    UInt64(CTotal) * 8) as IXOF;
+  LSizedXof.Initialize;
+  LSizedXof.TransformBytes(LData);
+  LSized := nil;
+  System.SetLength(LSized, CTotal);
+  LSizedXof.DoOutput(LSized, 0, CTotal);
+
+  // streaming KMAC-XOF squeezed in uneven chunks
+  LStream := THashFactory.TXOF.CreateKMAC128XOFStream(LKey, LCustomization);
+  LStream.Initialize;
+  LStream.TransformBytes(LData);
+  LStreamed := nil;
+  System.SetLength(LStreamed, CTotal);
+  LOffset := 0;
+  LIdx := 0;
+  while LOffset < CTotal do
+  begin
+    LChunkSize := CChunks[LIdx mod System.Length(CChunks)];
+    if LChunkSize > (CTotal - LOffset) then
+    begin
+      LChunkSize := CTotal - LOffset;
+    end;
+    LStream.Squeeze(LStreamed, LOffset, LChunkSize);
+    System.Inc(LOffset, LChunkSize);
+    System.Inc(LIdx);
+  end;
+
+  CheckTrue(AreEqual(LSized, LStreamed),
+    'KMAC128XOF stream Squeeze does not match sized DoOutput');
+end;
+
 { TTestKMAC256 }
 
 procedure TTestKMAC256.DoComputeKMAC256(const AKey, ACustomization, AData,
@@ -3786,6 +4057,104 @@ begin
   DoComputeKMAC256(RawKeyInHex, CustomizationMessage, FData,
     'D5BE731C954ED7732846BB59DBE3A8E30F83E77A4BFF4459F2F1C2B4ECEBB8CE67BA01C62E8AB8578D2D499BD1BB276768781190020A306A97DE281DCC30305D',
     OutputSizeInBits, True);
+end;
+
+procedure TTestKMAC256.TestKMAC256XOFMultiChunkConsistency;
+const
+  CTotal = Int32(512);
+  CChunks: array [0 .. 4] of Int32 = (1, 7, 13, 64, 100);
+var
+  LKey, LCustomization, LData, LSingle, LChunked: TBytes;
+  LXof1, LXof2: IXOF;
+  LOffset, LChunkSize, LIdx: Int32;
+begin
+  LKey := TConverters.ConvertHexStringToBytes(RawKeyInHex);
+  LCustomization := TConverters.ConvertStringToBytes(CustomizationMessage,
+    TEncoding.UTF8);
+  LData := TConverters.ConvertHexStringToBytes(FData);
+
+  // single-call DoOutput reference
+  LXof1 := THashFactory.TXOF.CreateKMAC256XOF(LKey, LCustomization,
+    UInt64(CTotal) * 8) as IXOF;
+  LXof1.Initialize;
+  LXof1.TransformBytes(LData);
+  LSingle := nil;
+  System.SetLength(LSingle, CTotal);
+  LXof1.DoOutput(LSingle, 0, CTotal);
+
+  // multi-chunk (3+ uneven) DoOutput: regression gate ensuring RightEncode is
+  // appended exactly once across successive output calls
+  LXof2 := THashFactory.TXOF.CreateKMAC256XOF(LKey, LCustomization,
+    UInt64(CTotal) * 8) as IXOF;
+  LXof2.Initialize;
+  LXof2.TransformBytes(LData);
+  LChunked := nil;
+  System.SetLength(LChunked, CTotal);
+  LOffset := 0;
+  LIdx := 0;
+  while LOffset < CTotal do
+  begin
+    LChunkSize := CChunks[LIdx mod System.Length(CChunks)];
+    if LChunkSize > (CTotal - LOffset) then
+    begin
+      LChunkSize := CTotal - LOffset;
+    end;
+    LXof2.DoOutput(LChunked, LOffset, LChunkSize);
+    System.Inc(LOffset, LChunkSize);
+    System.Inc(LIdx);
+  end;
+
+  CheckTrue(AreEqual(LSingle, LChunked),
+    'KMAC256XOF multi-chunk DoOutput does not match single DoOutput ' +
+    '(RightEncode-once regression)');
+end;
+
+procedure TTestKMAC256.TestKMAC256XOFStreamMatchesSized;
+const
+  CTotal = Int32(512);
+  CChunks: array [0 .. 4] of Int32 = (1, 7, 13, 64, 100);
+var
+  LKey, LCustomization, LData, LSized, LStreamed: TBytes;
+  LSizedXof: IXOF;
+  LStream: IXOFStream;
+  LOffset, LChunkSize, LIdx: Int32;
+begin
+  LKey := TConverters.ConvertHexStringToBytes(RawKeyInHex);
+  LCustomization := TConverters.ConvertStringToBytes(CustomizationMessage,
+    TEncoding.UTF8);
+  LData := TConverters.ConvertHexStringToBytes(FData);
+
+  // sized KMAC-XOF reference (already NIST-verified via the samples above)
+  LSizedXof := THashFactory.TXOF.CreateKMAC256XOF(LKey, LCustomization,
+    UInt64(CTotal) * 8) as IXOF;
+  LSizedXof.Initialize;
+  LSizedXof.TransformBytes(LData);
+  LSized := nil;
+  System.SetLength(LSized, CTotal);
+  LSizedXof.DoOutput(LSized, 0, CTotal);
+
+  // streaming KMAC-XOF squeezed in uneven chunks
+  LStream := THashFactory.TXOF.CreateKMAC256XOFStream(LKey, LCustomization);
+  LStream.Initialize;
+  LStream.TransformBytes(LData);
+  LStreamed := nil;
+  System.SetLength(LStreamed, CTotal);
+  LOffset := 0;
+  LIdx := 0;
+  while LOffset < CTotal do
+  begin
+    LChunkSize := CChunks[LIdx mod System.Length(CChunks)];
+    if LChunkSize > (CTotal - LOffset) then
+    begin
+      LChunkSize := CTotal - LOffset;
+    end;
+    LStream.Squeeze(LStreamed, LOffset, LChunkSize);
+    System.Inc(LOffset, LChunkSize);
+    System.Inc(LIdx);
+  end;
+
+  CheckTrue(AreEqual(LSized, LStreamed),
+    'KMAC256XOF stream Squeeze does not match sized DoOutput');
 end;
 
 { TTestBlake2BMAC }
@@ -4148,6 +4517,13 @@ RegisterTest(TTestBlake2BP);
 RegisterTest(TTestBlake2SP);
 RegisterTest(TTestBlake3);
 RegisterTest(TTestBlake3XOF);
+RegisterTest(TTestShake_128Stream);
+RegisterTest(TTestShake_256Stream);
+RegisterTest(TTestCShake_128Stream);
+RegisterTest(TTestCShake_256Stream);
+RegisterTest(TTestBlake2XSStream);
+RegisterTest(TTestBlake2XBStream);
+RegisterTest(TTestBlake3XOFStream);
 {$ELSE}
 // Crypto
 RegisterTest(TTestGost.Suite);
@@ -4237,6 +4613,13 @@ RegisterTest(TTestBlake2BP.Suite);
 RegisterTest(TTestBlake2SP.Suite);
 RegisterTest(TTestBlake3.Suite);
 RegisterTest(TTestBlake3XOF.Suite);
+RegisterTest(TTestShake_128Stream.Suite);
+RegisterTest(TTestShake_256Stream.Suite);
+RegisterTest(TTestCShake_128Stream.Suite);
+RegisterTest(TTestCShake_256Stream.Suite);
+RegisterTest(TTestBlake2XSStream.Suite);
+RegisterTest(TTestBlake2XBStream.Suite);
+RegisterTest(TTestBlake3XOFStream.Suite);
 {$ENDIF FPC}
 
 end.

--- a/HashLib.Tests/src/HashLibTestBase.pas
+++ b/HashLib.Tests/src/HashLibTestBase.pas
@@ -451,6 +451,44 @@ type
 
   end;
 
+type
+  // Base class for streaming-XOF (IXOFStream) tests. Each concrete test pairs a
+  // streaming instance with a reference IXOF configured for the *same* mode, so
+  // that Squeeze output can be cross-checked against the already NIST-verified
+  // DoOutput path. This validates the new streaming API, uneven-chunk
+  // continuity, the squeezed-byte counter, buffer guards and re-initialization,
+  // without requiring new hard-coded vectors.
+  TXofStreamAlgorithmTestCase = class abstract(THashLibAlgorithmTestCase)
+
+  strict private
+  const
+    CComparisonLength = Int32(512);
+  var
+    FStreamInstance: IXOFStream;
+    FReferenceXof: IXOF;
+
+    function GetStreamInstance: IXOFStream; inline;
+    procedure SetStreamInstance(const AValue: IXOFStream); inline;
+    function GetReferenceXof: IXOF; inline;
+    procedure SetReferenceXof(const AValue: IXOF); inline;
+
+    procedure FeedEmptyData();
+    procedure CallShouldRaiseException();
+
+  strict protected
+    property StreamInstance: IXOFStream read GetStreamInstance
+      write SetStreamInstance;
+    property ReferenceXof: IXOF read GetReferenceXof write SetReferenceXof;
+  published
+    procedure TestSqueezeMatchesReference;
+    procedure TestUnevenChunkedSqueezeMatchesReference;
+    procedure TestBytesSqueezedTracksOutput;
+    procedure TestSqueezeBufferTooShort;
+    procedure TestReInitializeResetsStream;
+    procedure TestStreamShouldRaiseExceptionOnWriteAfterRead;
+
+  end;
+
 implementation
 
 { THashLibTestCase }
@@ -1304,6 +1342,162 @@ begin
 end;
 
 procedure TXofAlgorithmTestCase.TestXofShouldRaiseExceptionOnWriteAfterRead;
+var
+  LTestMethod: TTestMethod;
+begin
+  LTestMethod := CallShouldRaiseException;
+  CheckException(LTestMethod, EInvalidOperationHashLibException);
+end;
+
+{ TXofStreamAlgorithmTestCase }
+
+function TXofStreamAlgorithmTestCase.GetStreamInstance: IXOFStream;
+begin
+  Result := FStreamInstance;
+end;
+
+procedure TXofStreamAlgorithmTestCase.SetStreamInstance(const AValue
+  : IXOFStream);
+begin
+  FStreamInstance := AValue;
+end;
+
+function TXofStreamAlgorithmTestCase.GetReferenceXof: IXOF;
+begin
+  Result := FReferenceXof;
+end;
+
+procedure TXofStreamAlgorithmTestCase.SetReferenceXof(const AValue: IXOF);
+begin
+  FReferenceXof := AValue;
+end;
+
+procedure TXofStreamAlgorithmTestCase.FeedEmptyData();
+begin
+  StreamInstance.Initialize;
+  StreamInstance.TransformString(EmptyData, TEncoding.UTF8);
+  ReferenceXof.Initialize;
+  ReferenceXof.TransformString(EmptyData, TEncoding.UTF8);
+end;
+
+procedure TXofStreamAlgorithmTestCase.CallShouldRaiseException();
+begin
+  StreamInstance.Initialize;
+  StreamInstance.TransformUntyped(BytesABCDE, System.SizeOf(BytesABCDE));
+  StreamInstance.Squeeze(32);
+  // this call below should raise since output has already been read from the Xof
+  StreamInstance.TransformUntyped(BytesABCDE, System.SizeOf(BytesABCDE));
+end;
+
+procedure TXofStreamAlgorithmTestCase.TestSqueezeMatchesReference;
+var
+  LStreamOut, LReferenceOut: TBytes;
+begin
+  FeedEmptyData();
+
+  LStreamOut := StreamInstance.Squeeze(CComparisonLength);
+
+  LReferenceOut := nil;
+  System.SetLength(LReferenceOut, CComparisonLength);
+  ReferenceXof.DoOutput(LReferenceOut, 0, CComparisonLength);
+
+  CheckTrue(AreEqual(LStreamOut, LReferenceOut),
+    Format('%s Stream Squeeze does not match reference DoOutput',
+    [StreamInstance.Name]));
+end;
+
+procedure TXofStreamAlgorithmTestCase.TestUnevenChunkedSqueezeMatchesReference;
+const
+  CChunkSizes: array [0 .. 4] of Int32 = (1, 7, 13, 64, 100);
+var
+  LStreamOut, LReferenceOut: TBytes;
+  LOffset, LChunkSize, LIdx: Int32;
+begin
+  FeedEmptyData();
+
+  LStreamOut := nil;
+  System.SetLength(LStreamOut, CComparisonLength);
+  LOffset := 0;
+  LIdx := 0;
+  // squeeze the same output in many uneven chunks; this is the key regression
+  // gate for block-boundary handling inside the squeeze engine
+  while LOffset < CComparisonLength do
+  begin
+    LChunkSize := CChunkSizes[LIdx mod System.Length(CChunkSizes)];
+    if LChunkSize > (CComparisonLength - LOffset) then
+    begin
+      LChunkSize := CComparisonLength - LOffset;
+    end;
+    StreamInstance.Squeeze(LStreamOut, LOffset, LChunkSize);
+    System.Inc(LOffset, LChunkSize);
+    System.Inc(LIdx);
+  end;
+
+  LReferenceOut := nil;
+  System.SetLength(LReferenceOut, CComparisonLength);
+  ReferenceXof.DoOutput(LReferenceOut, 0, CComparisonLength);
+
+  CheckTrue(AreEqual(LStreamOut, LReferenceOut),
+    Format('%s Uneven chunked Squeeze does not match reference DoOutput',
+    [StreamInstance.Name]));
+end;
+
+procedure TXofStreamAlgorithmTestCase.TestBytesSqueezedTracksOutput;
+begin
+  FeedEmptyData();
+
+  CheckEquals(Int64(0), Int64(StreamInstance.BytesSqueezed),
+    'BytesSqueezed should be 0 before any output');
+
+  StreamInstance.Squeeze(100);
+  CheckEquals(Int64(100), Int64(StreamInstance.BytesSqueezed),
+    'BytesSqueezed should be 100 after squeezing 100 bytes');
+
+  StreamInstance.Squeeze(50);
+  CheckEquals(Int64(150), Int64(StreamInstance.BytesSqueezed),
+    'BytesSqueezed should be 150 after squeezing 50 more bytes');
+end;
+
+procedure TXofStreamAlgorithmTestCase.TestSqueezeBufferTooShort;
+var
+  LOutput: TBytes;
+begin
+  StreamInstance.Initialize;
+  StreamInstance.TransformString(EmptyData, TEncoding.UTF8);
+
+  LOutput := nil;
+  System.SetLength(LOutput, 10);
+
+  try
+    StreamInstance.Squeeze(LOutput, 1, 10);
+    Fail('no exception');
+  except
+    on e: EArgumentOutOfRangeHashLibException do
+    begin
+      CheckEquals('Output Buffer Too Short', e.Message);
+    end;
+  end;
+end;
+
+procedure TXofStreamAlgorithmTestCase.TestReInitializeResetsStream;
+var
+  LFirst, LSecond: TBytes;
+begin
+  StreamInstance.Initialize;
+  StreamInstance.TransformString(EmptyData, TEncoding.UTF8);
+  LFirst := StreamInstance.Squeeze(CComparisonLength);
+
+  // re-initialize and squeeze again; output must be identical
+  StreamInstance.Initialize;
+  StreamInstance.TransformString(EmptyData, TEncoding.UTF8);
+  LSecond := StreamInstance.Squeeze(CComparisonLength);
+
+  CheckTrue(AreEqual(LFirst, LSecond),
+    Format('%s re-initialization did not reset the stream',
+    [StreamInstance.Name]));
+end;
+
+procedure TXofStreamAlgorithmTestCase.TestStreamShouldRaiseExceptionOnWriteAfterRead;
 var
   LTestMethod: TTestMethod;
 begin

--- a/HashLib/src/Base/HlpHashFactory.pas
+++ b/HashLib/src/Base/HlpHashFactory.pas
@@ -469,6 +469,36 @@ type
       class function CreateBlake3XOF(const AKey: THashLibByteArray;
         AXofSizeInBits: UInt64): IHash; overload; static;
 
+      // ----- Streaming XOF constructors (continuous squeeze) ----- //
+      // These return IXOFStream instances whose output length need not be
+      // declared upfront; use Squeeze to pull bytes on demand.
+
+      class function CreateShake_128Stream(): IXOFStream; static;
+      class function CreateShake_256Stream(): IXOFStream; static;
+
+      class function CreateCShake_128Stream(const AN, &AS: THashLibByteArray)
+        : IXOFStream; static;
+      class function CreateCShake_256Stream(const AN, &AS: THashLibByteArray)
+        : IXOFStream; static;
+
+      class function CreateBlake2XSStream(const ABlake2XSConfig
+        : TBlake2XSConfig): IXOFStream; overload; static;
+      class function CreateBlake2XSStream(const AKey: THashLibByteArray)
+        : IXOFStream; overload; static;
+
+      class function CreateBlake2XBStream(const ABlake2XBConfig
+        : TBlake2XBConfig): IXOFStream; overload; static;
+      class function CreateBlake2XBStream(const AKey: THashLibByteArray)
+        : IXOFStream; overload; static;
+
+      class function CreateKMAC128XOFStream(const AKMACKey, ACustomization
+        : THashLibByteArray): IXOFStream; static;
+      class function CreateKMAC256XOFStream(const AKMACKey, ACustomization
+        : THashLibByteArray): IXOFStream; static;
+
+      class function CreateBlake3XOFStream(const AKey: THashLibByteArray)
+        : IXOFStream; static;
+
     end;
 
     // ====================== THMAC ====================== //
@@ -1523,6 +1553,93 @@ class function THashFactory.TXOF.CreateKMAC256XOF(const AKMACKey,
 begin
   Result := TKMAC256XOF.CreateKMAC256XOF(AKMACKey, ACustomization,
     AXofSizeInBits);
+end;
+
+class function THashFactory.TXOF.CreateShake_128Stream(): IXOFStream;
+var
+  LStream: IXOFStream;
+begin
+  LStream := TShake_128.Create();
+  Result := LStream;
+end;
+
+class function THashFactory.TXOF.CreateShake_256Stream(): IXOFStream;
+var
+  LStream: IXOFStream;
+begin
+  LStream := TShake_256.Create();
+  Result := LStream;
+end;
+
+class function THashFactory.TXOF.CreateCShake_128Stream(const AN,
+  &AS: THashLibByteArray): IXOFStream;
+var
+  LStream: IXOFStream;
+begin
+  LStream := TCShake_128.Create(AN, &AS);
+  Result := LStream;
+end;
+
+class function THashFactory.TXOF.CreateCShake_256Stream(const AN,
+  &AS: THashLibByteArray): IXOFStream;
+var
+  LStream: IXOFStream;
+begin
+  LStream := TCShake_256.Create(AN, &AS);
+  Result := LStream;
+end;
+
+class function THashFactory.TXOF.CreateBlake2XSStream(const ABlake2XSConfig
+  : TBlake2XSConfig): IXOFStream;
+begin
+  Result := TBlake2XS.CreateBlake2XSXofStream(ABlake2XSConfig);
+end;
+
+class function THashFactory.TXOF.CreateBlake2XSStream(const AKey
+  : THashLibByteArray): IXOFStream;
+var
+  LConfig: IBlake2SConfig;
+begin
+  LConfig := TBlake2SConfig.Create(32);
+  LConfig.Key := AKey;
+  Result := CreateBlake2XSStream(TBlake2XSConfig.Create(LConfig, nil));
+end;
+
+class function THashFactory.TXOF.CreateBlake2XBStream(const ABlake2XBConfig
+  : TBlake2XBConfig): IXOFStream;
+begin
+  Result := TBlake2XB.CreateBlake2XBXofStream(ABlake2XBConfig);
+end;
+
+class function THashFactory.TXOF.CreateBlake2XBStream(const AKey
+  : THashLibByteArray): IXOFStream;
+var
+  LConfig: IBlake2BConfig;
+begin
+  LConfig := TBlake2BConfig.Create(64);
+  LConfig.Key := AKey;
+  Result := CreateBlake2XBStream(TBlake2XBConfig.Create(LConfig, nil));
+end;
+
+class function THashFactory.TXOF.CreateKMAC128XOFStream(const AKMACKey,
+  ACustomization: THashLibByteArray): IXOFStream;
+begin
+  Result := TKMAC128XOF.CreateKMAC128XOFStream(AKMACKey, ACustomization);
+end;
+
+class function THashFactory.TXOF.CreateKMAC256XOFStream(const AKMACKey,
+  ACustomization: THashLibByteArray): IXOFStream;
+begin
+  Result := TKMAC256XOF.CreateKMAC256XOFStream(AKMACKey, ACustomization);
+end;
+
+class function THashFactory.TXOF.CreateBlake3XOFStream(const AKey
+  : THashLibByteArray): IXOFStream;
+var
+  LStream: IXOFStream;
+begin
+  LStream := TBlake3XOF.Create(32, AKey);
+  Result := LStream;
 end;
 
 { THashFactory.THMAC }

--- a/HashLib/src/Crypto/HlpBlake2B.pas
+++ b/HashLib/src/Crypto/HlpBlake2B.pas
@@ -109,7 +109,7 @@ type
   end;
 
 type
-  TBlake2XB = class sealed(TBlake2B, IXOF)
+  TBlake2XB = class sealed(TBlake2B, IXOF, IXOFStream)
   strict private
   const
     Blake2BHashSize = Int32(64);
@@ -134,8 +134,6 @@ type
     function NodeOffsetWithXOFDigestLength(AXOFSizeInBytes: UInt64)
       : UInt64; inline;
 
-    function ComputeStepLength(): Int32; inline;
-
     function GetResult(): THashLibByteArray; reintroduce;
 
     constructor CreateInternal(const AConfig: IBlake2BConfig;
@@ -144,12 +142,12 @@ type
   strict protected
   var
     FBlake2XBConfig: TBlake2XBConfig;
-    FDigestPosition: UInt64;
     FRootConfig, FOutputConfig: TBlake2XBConfig;
-    FRootHashDigest, FBlake2XBBuffer: THashLibByteArray;
-    FFinalized: Boolean;
+    // squeeze engine; nil until the first output (lazily finalized)
+    FReader: IXofReader;
 
     function GetName: String; override;
+    procedure EnsureReader();
     property XOFSizeInBits: UInt64 read GetXOFSizeInBits write SetXOFSizeInBits;
 
   public
@@ -163,6 +161,21 @@ type
 
     procedure DoOutput(const ADestination: THashLibByteArray;
       ADestinationOffset, AOutputLength: UInt64);
+
+    procedure Squeeze(const ADestination: THashLibByteArray;
+      ADestinationOffset, AOutputLength: UInt64); overload;
+    function Squeeze(AOutputLength: UInt64): THashLibByteArray; overload;
+    function GetBytesSqueezed: UInt64;
+
+    /// <summary>
+    /// Creates a Blake2XB instance in unknown-length (streaming) mode. Unlike
+    /// SHAKE/Blake3, Blake2X bakes the final digest length into every output
+    /// block, so unbounded output must be selected at construction by encoding
+    /// the spec's reserved "unknown length" marker. This factory hides that
+    /// marker so callers never deal with the magic value directly.
+    /// </summary>
+    class function CreateBlake2XBXofStream(const ABlake2XBConfig
+      : TBlake2XBConfig): IXOFStream; static;
 
   end;
 
@@ -210,6 +223,128 @@ implementation
 
 uses
   HlpBlake2BDispatch;
+
+type
+  // Self-contained Blake2XB squeeze engine. Owns the finalized root digest and
+  // its own copy of the output config; generates output blocks on demand. The
+  // size cap is enforced by the owning TBlake2XB, not here.
+  TBlake2XBXofReader = class sealed(TInterfacedObject, IXofReader)
+  strict private
+  const
+    Blake2BHashSize = Int32(64);
+  var
+    FRootHashDigest, FBlake2XBBuffer: THashLibByteArray;
+    FOutputConfig: TBlake2XBConfig;
+    FXofSizeInBytes: UInt64;
+    FUnknownLength: Boolean;
+    FDigestPosition: UInt64;
+    function ComputeStepLength(): Int32; inline;
+  public
+    constructor Create(const ARootHashDigest: THashLibByteArray;
+      const AOutputConfig: TBlake2XBConfig; AXofSizeInBytes: UInt64;
+      AUnknownLength: Boolean);
+    procedure Read(const ADestination: THashLibByteArray;
+      ADestinationOffset, AOutputLength: UInt64);
+    function GetPosition: UInt64;
+    function Clone(): IXofReader;
+  end;
+
+{ TBlake2XBXofReader }
+
+constructor TBlake2XBXofReader.Create(const ARootHashDigest: THashLibByteArray;
+  const AOutputConfig: TBlake2XBConfig; AXofSizeInBytes: UInt64;
+  AUnknownLength: Boolean);
+begin
+  inherited Create();
+  FRootHashDigest := System.Copy(ARootHashDigest);
+  FOutputConfig := AOutputConfig.Clone();
+  FXofSizeInBytes := AXofSizeInBytes;
+  FUnknownLength := AUnknownLength;
+  FDigestPosition := 0;
+  System.SetLength(FBlake2XBBuffer, Blake2BHashSize);
+end;
+
+function TBlake2XBXofReader.ComputeStepLength: Int32;
+var
+  LDiff: UInt64;
+begin
+  if FUnknownLength then
+  begin
+    Result := Blake2BHashSize;
+    Exit;
+  end;
+
+  LDiff := FXofSizeInBytes - FDigestPosition;
+
+  // Math.Min
+  if UInt64(Blake2BHashSize) < LDiff then
+  begin
+    Result := UInt64(Blake2BHashSize)
+  end
+  else
+  begin
+    Result := LDiff;
+  end;
+end;
+
+function TBlake2XBXofReader.GetPosition: UInt64;
+begin
+  Result := FDigestPosition;
+end;
+
+procedure TBlake2XBXofReader.Read(const ADestination: THashLibByteArray;
+  ADestinationOffset, AOutputLength: UInt64);
+var
+  LDiff, LCount, LBlockOffset: UInt64;
+  LHash: IHash;
+begin
+  while AOutputLength > 0 do
+  begin
+    if (FDigestPosition and (Blake2BHashSize - 1)) = 0 then
+    begin
+      FOutputConfig.Blake2BConfig.HashSize := ComputeStepLength();
+      FOutputConfig.Blake2BTreeConfig.InnerHashSize := Blake2BHashSize;
+
+      LHash := TBlake2B.Create(FOutputConfig.Blake2BConfig,
+        FOutputConfig.Blake2BTreeConfig);
+      FBlake2XBBuffer := LHash.ComputeBytes(FRootHashDigest).GetBytes();
+      FOutputConfig.Blake2BTreeConfig.NodeOffset :=
+        FOutputConfig.Blake2BTreeConfig.NodeOffset + 1;
+    end;
+
+    LBlockOffset := FDigestPosition and (Blake2BHashSize - 1);
+
+    LDiff := UInt64(System.Length(FBlake2XBBuffer)) - LBlockOffset;
+
+    // Math.Min
+    if AOutputLength < LDiff then
+    begin
+      LCount := AOutputLength
+    end
+    else
+    begin
+      LCount := LDiff;
+    end;
+
+    System.Move(FBlake2XBBuffer[LBlockOffset], ADestination[ADestinationOffset],
+      LCount);
+
+    System.Dec(AOutputLength, LCount);
+    System.Inc(ADestinationOffset, LCount);
+    System.Inc(FDigestPosition, LCount);
+  end;
+end;
+
+function TBlake2XBXofReader.Clone(): IXofReader;
+var
+  LReader: TBlake2XBXofReader;
+begin
+  LReader := TBlake2XBXofReader.Create(FRootHashDigest, FOutputConfig,
+    FXofSizeInBytes, FUnknownLength);
+  LReader.FBlake2XBBuffer := System.Copy(FBlake2XBBuffer);
+  LReader.FDigestPosition := FDigestPosition;
+  Result := LReader;
+end;
 
 { TBlake2B }
 
@@ -510,29 +645,6 @@ begin
   Result := (UInt64(AXOFSizeInBytes) shl 32);
 end;
 
-function TBlake2XB.ComputeStepLength: Int32;
-var
-  LXofSizeInBytes, LDiff: UInt64;
-begin
-  LXofSizeInBytes := XOFSizeInBits shr 3;
-  LDiff := LXofSizeInBytes - FDigestPosition;
-  if (LXofSizeInBytes = UInt64(UnknownDigestLengthInBytes)) then
-  begin
-    Result := Blake2BHashSize;
-    Exit;
-  end;
-
-  // Math.Min
-  if UInt64(Blake2BHashSize) < LDiff then
-  begin
-    Result := UInt64(Blake2BHashSize)
-  end
-  else
-  begin
-    Result := LDiff;
-  end;
-end;
-
 function TBlake2XB.GetName: String;
 begin
   Result := Self.ClassName;
@@ -551,12 +663,12 @@ begin
   // Blake2XB Cloning
   LHashInstance := LXof as TBlake2XB;
   LHashInstance.FBlake2XBConfig := FBlake2XBConfig.Clone();
-  LHashInstance.FDigestPosition := FDigestPosition;
   LHashInstance.FRootConfig := FRootConfig.Clone();
   LHashInstance.FOutputConfig := FOutputConfig.Clone();
-  LHashInstance.FRootHashDigest := System.Copy(FRootHashDigest);
-  LHashInstance.FBlake2XBBuffer := System.Copy(FBlake2XBBuffer);
-  LHashInstance.FFinalized := FFinalized;
+  if FReader <> nil then
+  begin
+    LHashInstance.FReader := FReader.Clone();
+  end;
 
   // Internal Blake2B Cloning
   System.Move(FM, LHashInstance.FM, System.SizeOf(FM));
@@ -624,8 +736,18 @@ begin
   FOutputConfig.Blake2BTreeConfig := TBlake2BTreeConfig.Create();
 
   CreateInternal(FRootConfig.Blake2BConfig, FRootConfig.Blake2BTreeConfig);
+end;
 
-  System.SetLength(FBlake2XBBuffer, Blake2BHashSize);
+class function TBlake2XB.CreateBlake2XBXofStream(const ABlake2XBConfig
+  : TBlake2XBConfig): IXOFStream;
+var
+  LXof: TBlake2XB;
+begin
+  LXof := TBlake2XB.Create(ABlake2XBConfig);
+  // Select unbounded output by encoding the spec's "unknown length" marker
+  // into the XOF digest-length field; this is the streaming mode for Blake2X.
+  LXof.FXOFSizeInBits := UInt64(UnknownDigestLengthInBytes) shl 3;
+  Result := LXof;
 end;
 
 procedure TBlake2XB.Initialize;
@@ -640,18 +762,36 @@ begin
   FOutputConfig.Blake2BTreeConfig.NodeOffset := NodeOffsetWithXOFDigestLength
     (LXofSizeInBytes);
 
-  FRootHashDigest := nil;
-  FDigestPosition := 0;
-  FFinalized := False;
-  TArrayUtils.ZeroFill(FBlake2XBBuffer);
+  FReader := nil;
   inherited Initialize();
+end;
+
+procedure TBlake2XB.EnsureReader();
+var
+  LRootHashDigest: THashLibByteArray;
+  LXofSizeInBytes: UInt64;
+begin
+  if FReader <> nil then
+  begin
+    Exit;
+  end;
+
+  Finish();
+
+  // Get root digest from the finalized state
+  System.SetLength(LRootHashDigest, Blake2BHashSize);
+  TBinaryPrimitives.CopyUInt64LittleEndian(PUInt64(FState), 0,
+    PByte(LRootHashDigest), 0, System.Length(LRootHashDigest));
+
+  LXofSizeInBytes := XOFSizeInBits shr 3;
+  FReader := TBlake2XBXofReader.Create(LRootHashDigest, FOutputConfig,
+    LXofSizeInBytes, LXofSizeInBytes = UInt64(UnknownDigestLengthInBytes));
 end;
 
 procedure TBlake2XB.DoOutput(const ADestination: THashLibByteArray;
   ADestinationOffset, AOutputLength: UInt64);
 var
-  LDiff, LCount, LBlockOffset: UInt64;
-  LHash: IHash;
+  LPosition: UInt64;
 begin
 
   if (UInt64(System.Length(ADestination)) - ADestinationOffset) < AOutputLength
@@ -660,67 +800,62 @@ begin
     raise EArgumentOutOfRangeHashLibException.CreateRes(@SOutputBufferTooShort);
   end;
 
+  if FReader = nil then
+  begin
+    LPosition := 0;
+  end
+  else
+  begin
+    LPosition := FReader.Position;
+  end;
+
   if ((XOFSizeInBits shr 3) <> UnknownDigestLengthInBytes) then
   begin
-    if ((FDigestPosition + AOutputLength) > (XOFSizeInBits shr 3)) then
+    if ((LPosition + AOutputLength) > (XOFSizeInBits shr 3)) then
     begin
       raise EArgumentOutOfRangeHashLibException.CreateRes
         (@SOutputLengthInvalid);
     end;
   end
-  else if (FDigestPosition = UnknownMaxDigestLengthInBytes) then
+  else if (LPosition = UnknownMaxDigestLengthInBytes) then
   begin
     raise EArgumentOutOfRangeHashLibException.CreateRes
       (@SMaximumOutputLengthExceeded);
   end;
 
-  if not FFinalized then
+  EnsureReader();
+  FReader.Read(ADestination, ADestinationOffset, AOutputLength);
+end;
+
+procedure TBlake2XB.Squeeze(const ADestination: THashLibByteArray;
+  ADestinationOffset, AOutputLength: UInt64);
+begin
+  // For Blake2X the output is always bounded by the mode's maximum (the
+  // declared size when known, or UnknownMaxDigestLengthInBytes when the
+  // instance was created for streaming). The cap logic is therefore the
+  // same as DoOutput; unbounded streaming comes from unknown-length
+  // construction, not from bypassing the cap.
+  DoOutput(ADestination, ADestinationOffset, AOutputLength);
+end;
+
+function TBlake2XB.Squeeze(AOutputLength: UInt64): THashLibByteArray;
+begin
+  System.SetLength(Result, AOutputLength);
+  if AOutputLength > 0 then
   begin
-    Finish();
-    FFinalized := True;
+    Squeeze(Result, 0, AOutputLength);
   end;
+end;
 
-  if (FRootHashDigest = nil) then
+function TBlake2XB.GetBytesSqueezed: UInt64;
+begin
+  if FReader = nil then
   begin
-    // Get root digest
-    System.SetLength(FRootHashDigest, Blake2BHashSize);
-    TBinaryPrimitives.CopyUInt64LittleEndian(PUInt64(FState), 0, PByte(FRootHashDigest), 0,
-      System.Length(FRootHashDigest));
-  end;
-
-  while AOutputLength > 0 do
+    Result := 0;
+  end
+  else
   begin
-    if (FDigestPosition and (Blake2BHashSize - 1)) = 0 then
-    begin
-      FOutputConfig.Blake2BConfig.HashSize := ComputeStepLength();
-      FOutputConfig.Blake2BTreeConfig.InnerHashSize := Blake2BHashSize;
-
-      LHash := TBlake2B.Create(FOutputConfig.Blake2BConfig, FOutputConfig.Blake2BTreeConfig);
-      FBlake2XBBuffer := LHash.ComputeBytes(FRootHashDigest).GetBytes();
-      FOutputConfig.Blake2BTreeConfig.NodeOffset :=
-        FOutputConfig.Blake2BTreeConfig.NodeOffset + 1;
-    end;
-
-    LBlockOffset := FDigestPosition and (Blake2BHashSize - 1);
-
-    LDiff := UInt64(System.Length(FBlake2XBBuffer)) - LBlockOffset;
-
-    // Math.Min
-    if AOutputLength < LDiff then
-    begin
-      LCount := AOutputLength
-    end
-    else
-    begin
-      LCount := LDiff;
-    end;
-
-    System.Move(FBlake2XBBuffer[LBlockOffset],
-      ADestination[ADestinationOffset], LCount);
-
-    System.Dec(AOutputLength, LCount);
-    System.Inc(ADestinationOffset, LCount);
-    System.Inc(FDigestPosition, LCount);
+    Result := FReader.Position;
   end;
 end;
 
@@ -740,7 +875,7 @@ end;
 procedure TBlake2XB.TransformBytes(const AData: THashLibByteArray;
   AIndex, ADataLength: Int32);
 begin
-  if FFinalized then
+  if FReader <> nil then
   begin
     raise EInvalidOperationHashLibException.CreateResFmt
       (@SWritetoXofAfterReadError, [Name]);

--- a/HashLib/src/Crypto/HlpBlake2S.pas
+++ b/HashLib/src/Crypto/HlpBlake2S.pas
@@ -109,7 +109,7 @@ type
   end;
 
 type
-  TBlake2XS = class sealed(TBlake2S, IXOF)
+  TBlake2XS = class sealed(TBlake2S, IXOF, IXOFStream)
   strict private
   const
     Blake2SHashSize = Int32(32);
@@ -133,8 +133,6 @@ type
     function NodeOffsetWithXOFDigestLength(AXOFSizeInBytes: UInt64)
       : UInt64; inline;
 
-    function ComputeStepLength(): Int32; inline;
-
     function GetResult(): THashLibByteArray; reintroduce;
 
     constructor CreateInternal(const AConfig: IBlake2SConfig;
@@ -143,12 +141,12 @@ type
   strict protected
   var
     FBlake2XSConfig: TBlake2XSConfig;
-    FDigestPosition: UInt64;
     FRootConfig, FOutputConfig: TBlake2XSConfig;
-    FRootHashDigest, FBlake2XSBuffer: THashLibByteArray;
-    FFinalized: Boolean;
+    // squeeze engine; nil until the first output (lazily finalized)
+    FReader: IXofReader;
 
     function GetName: String; override;
+    procedure EnsureReader();
     property XOFSizeInBits: UInt64 read GetXOFSizeInBits write SetXOFSizeInBits;
   public
 
@@ -161,6 +159,21 @@ type
 
     procedure DoOutput(const ADestination: THashLibByteArray;
       ADestinationOffset, AOutputLength: UInt64);
+
+    procedure Squeeze(const ADestination: THashLibByteArray;
+      ADestinationOffset, AOutputLength: UInt64); overload;
+    function Squeeze(AOutputLength: UInt64): THashLibByteArray; overload;
+    function GetBytesSqueezed: UInt64;
+
+    /// <summary>
+    /// Creates a Blake2XS instance in unknown-length (streaming) mode. Unlike
+    /// SHAKE/Blake3, Blake2X bakes the final digest length into every output
+    /// block, so unbounded output must be selected at construction by encoding
+    /// the spec's reserved "unknown length" marker. This factory hides that
+    /// marker so callers never deal with the magic value directly.
+    /// </summary>
+    class function CreateBlake2XSXofStream(const ABlake2XSConfig
+      : TBlake2XSConfig): IXOFStream; static;
 
   end;
 
@@ -208,6 +221,128 @@ implementation
 
 uses
   HlpBlake2SDispatch;
+
+type
+  // Self-contained Blake2XS squeeze engine. Owns the finalized root digest and
+  // its own copy of the output config; generates output blocks on demand. The
+  // size cap is enforced by the owning TBlake2XS, not here.
+  TBlake2XSXofReader = class sealed(TInterfacedObject, IXofReader)
+  strict private
+  const
+    Blake2SHashSize = Int32(32);
+  var
+    FRootHashDigest, FBlake2XSBuffer: THashLibByteArray;
+    FOutputConfig: TBlake2XSConfig;
+    FXofSizeInBytes: UInt64;
+    FUnknownLength: Boolean;
+    FDigestPosition: UInt64;
+    function ComputeStepLength(): Int32; inline;
+  public
+    constructor Create(const ARootHashDigest: THashLibByteArray;
+      const AOutputConfig: TBlake2XSConfig; AXofSizeInBytes: UInt64;
+      AUnknownLength: Boolean);
+    procedure Read(const ADestination: THashLibByteArray;
+      ADestinationOffset, AOutputLength: UInt64);
+    function GetPosition: UInt64;
+    function Clone(): IXofReader;
+  end;
+
+{ TBlake2XSXofReader }
+
+constructor TBlake2XSXofReader.Create(const ARootHashDigest: THashLibByteArray;
+  const AOutputConfig: TBlake2XSConfig; AXofSizeInBytes: UInt64;
+  AUnknownLength: Boolean);
+begin
+  inherited Create();
+  FRootHashDigest := System.Copy(ARootHashDigest);
+  FOutputConfig := AOutputConfig.Clone();
+  FXofSizeInBytes := AXofSizeInBytes;
+  FUnknownLength := AUnknownLength;
+  FDigestPosition := 0;
+  System.SetLength(FBlake2XSBuffer, Blake2SHashSize);
+end;
+
+function TBlake2XSXofReader.ComputeStepLength: Int32;
+var
+  LDiff: UInt64;
+begin
+  if FUnknownLength then
+  begin
+    Result := Blake2SHashSize;
+    Exit;
+  end;
+
+  LDiff := FXofSizeInBytes - FDigestPosition;
+
+  // Math.Min
+  if UInt64(Blake2SHashSize) < LDiff then
+  begin
+    Result := UInt64(Blake2SHashSize)
+  end
+  else
+  begin
+    Result := LDiff;
+  end;
+end;
+
+function TBlake2XSXofReader.GetPosition: UInt64;
+begin
+  Result := FDigestPosition;
+end;
+
+procedure TBlake2XSXofReader.Read(const ADestination: THashLibByteArray;
+  ADestinationOffset, AOutputLength: UInt64);
+var
+  LDiff, LCount, LBlockOffset: UInt64;
+  LHash: IHash;
+begin
+  while AOutputLength > 0 do
+  begin
+    if (FDigestPosition and (Blake2SHashSize - 1)) = 0 then
+    begin
+      FOutputConfig.Blake2SConfig.HashSize := ComputeStepLength();
+      FOutputConfig.Blake2STreeConfig.InnerHashSize := Blake2SHashSize;
+
+      LHash := TBlake2S.Create(FOutputConfig.Blake2SConfig,
+        FOutputConfig.Blake2STreeConfig);
+      FBlake2XSBuffer := LHash.ComputeBytes(FRootHashDigest).GetBytes();
+      FOutputConfig.Blake2STreeConfig.NodeOffset :=
+        FOutputConfig.Blake2STreeConfig.NodeOffset + 1;
+    end;
+
+    LBlockOffset := FDigestPosition and (Blake2SHashSize - 1);
+
+    LDiff := UInt64(System.Length(FBlake2XSBuffer)) - LBlockOffset;
+
+    // Math.Min
+    if AOutputLength < LDiff then
+    begin
+      LCount := AOutputLength
+    end
+    else
+    begin
+      LCount := LDiff;
+    end;
+
+    System.Move(FBlake2XSBuffer[LBlockOffset], ADestination[ADestinationOffset],
+      LCount);
+
+    System.Dec(AOutputLength, LCount);
+    System.Inc(ADestinationOffset, LCount);
+    System.Inc(FDigestPosition, LCount);
+  end;
+end;
+
+function TBlake2XSXofReader.Clone(): IXofReader;
+var
+  LReader: TBlake2XSXofReader;
+begin
+  LReader := TBlake2XSXofReader.Create(FRootHashDigest, FOutputConfig,
+    FXofSizeInBytes, FUnknownLength);
+  LReader.FBlake2XSBuffer := System.Copy(FBlake2XSBuffer);
+  LReader.FDigestPosition := FDigestPosition;
+  Result := LReader;
+end;
 
 { TBlake2S }
 
@@ -508,29 +643,6 @@ begin
   Result := (UInt64(AXOFSizeInBytes) shl 32);
 end;
 
-function TBlake2XS.ComputeStepLength: Int32;
-var
-  LXofSizeInBytes, LDiff: UInt64;
-begin
-  LXofSizeInBytes := XOFSizeInBits shr 3;
-  LDiff := LXofSizeInBytes - FDigestPosition;
-  if (LXofSizeInBytes = UInt64(UnknownDigestLengthInBytes)) then
-  begin
-    Result := Blake2SHashSize;
-    Exit;
-  end;
-
-  // Math.Min
-  if UInt64(Blake2SHashSize) < LDiff then
-  begin
-    Result := UInt64(Blake2SHashSize)
-  end
-  else
-  begin
-    Result := LDiff;
-  end;
-end;
-
 function TBlake2XS.GetName: String;
 begin
   Result := Self.ClassName;
@@ -548,12 +660,12 @@ begin
   // Blake2XS Cloning
   LHashInstance := LXof as TBlake2XS;
   LHashInstance.FBlake2XSConfig := FBlake2XSConfig.Clone();
-  LHashInstance.FDigestPosition := FDigestPosition;
   LHashInstance.FRootConfig := FRootConfig.Clone();
   LHashInstance.FOutputConfig := FOutputConfig.Clone();
-  LHashInstance.FRootHashDigest := System.Copy(FRootHashDigest);
-  LHashInstance.FBlake2XSBuffer := System.Copy(FBlake2XSBuffer);
-  LHashInstance.FFinalized := FFinalized;
+  if FReader <> nil then
+  begin
+    LHashInstance.FReader := FReader.Clone();
+  end;
 
   // Internal Blake2S Cloning
   System.Move(FM, LHashInstance.FM, System.SizeOf(FM));
@@ -621,7 +733,18 @@ begin
   FOutputConfig.Blake2STreeConfig := TBlake2STreeConfig.Create();
 
   CreateInternal(FRootConfig.Blake2SConfig, FRootConfig.Blake2STreeConfig);
-  System.SetLength(FBlake2XSBuffer, Blake2SHashSize);
+end;
+
+class function TBlake2XS.CreateBlake2XSXofStream(const ABlake2XSConfig
+  : TBlake2XSConfig): IXOFStream;
+var
+  LXof: TBlake2XS;
+begin
+  LXof := TBlake2XS.Create(ABlake2XSConfig);
+  // Select unbounded output by encoding the spec's "unknown length" marker
+  // into the XOF digest-length field; this is the streaming mode for Blake2X.
+  LXof.FXOFSizeInBits := UInt64(UnknownDigestLengthInBytes) shl 3;
+  Result := LXof;
 end;
 
 procedure TBlake2XS.Initialize;
@@ -635,18 +758,36 @@ begin
 
   FOutputConfig.Blake2STreeConfig.NodeOffset := NodeOffsetWithXOFDigestLength
     (LXofSizeInBytes);
-  FRootHashDigest := nil;
-  FDigestPosition := 0;
-  FFinalized := False;
-  TArrayUtils.ZeroFill(FBlake2XSBuffer);
+  FReader := nil;
   inherited Initialize();
+end;
+
+procedure TBlake2XS.EnsureReader();
+var
+  LRootHashDigest: THashLibByteArray;
+  LXofSizeInBytes: UInt64;
+begin
+  if FReader <> nil then
+  begin
+    Exit;
+  end;
+
+  Finish();
+
+  // Get root digest from the finalized state
+  System.SetLength(LRootHashDigest, Blake2SHashSize);
+  TBinaryPrimitives.CopyUInt32LittleEndian(PCardinal(FState), 0,
+    PByte(LRootHashDigest), 0, System.Length(LRootHashDigest));
+
+  LXofSizeInBytes := XOFSizeInBits shr 3;
+  FReader := TBlake2XSXofReader.Create(LRootHashDigest, FOutputConfig,
+    LXofSizeInBytes, LXofSizeInBytes = UInt64(UnknownDigestLengthInBytes));
 end;
 
 procedure TBlake2XS.DoOutput(const ADestination: THashLibByteArray;
   ADestinationOffset, AOutputLength: UInt64);
 var
-  LDiff, LCount, LBlockOffset: UInt64;
-  LHash: IHash;
+  LPosition: UInt64;
 begin
 
   if (UInt64(System.Length(ADestination)) - ADestinationOffset) < AOutputLength
@@ -655,67 +796,62 @@ begin
     raise EArgumentOutOfRangeHashLibException.CreateRes(@SOutputBufferTooShort);
   end;
 
+  if FReader = nil then
+  begin
+    LPosition := 0;
+  end
+  else
+  begin
+    LPosition := FReader.Position;
+  end;
+
   if ((XOFSizeInBits shr 3) <> UnknownDigestLengthInBytes) then
   begin
-    if ((FDigestPosition + AOutputLength) > (XOFSizeInBits shr 3)) then
+    if ((LPosition + AOutputLength) > (XOFSizeInBits shr 3)) then
     begin
       raise EArgumentOutOfRangeHashLibException.CreateRes
         (@SOutputLengthInvalid);
     end;
   end
-  else if (FDigestPosition = UnknownMaxDigestLengthInBytes) then
+  else if (LPosition = UnknownMaxDigestLengthInBytes) then
   begin
     raise EArgumentOutOfRangeHashLibException.CreateRes
       (@SMaximumOutputLengthExceeded);
   end;
 
-  if not FFinalized then
+  EnsureReader();
+  FReader.Read(ADestination, ADestinationOffset, AOutputLength);
+end;
+
+procedure TBlake2XS.Squeeze(const ADestination: THashLibByteArray;
+  ADestinationOffset, AOutputLength: UInt64);
+begin
+  // For Blake2X the output is always bounded by the mode's maximum (the
+  // declared size when known, or UnknownMaxDigestLengthInBytes when the
+  // instance was created for streaming). The cap logic is therefore the
+  // same as DoOutput; unbounded streaming comes from unknown-length
+  // construction, not from bypassing the cap.
+  DoOutput(ADestination, ADestinationOffset, AOutputLength);
+end;
+
+function TBlake2XS.Squeeze(AOutputLength: UInt64): THashLibByteArray;
+begin
+  System.SetLength(Result, AOutputLength);
+  if AOutputLength > 0 then
   begin
-    Finish();
-    FFinalized := True;
+    Squeeze(Result, 0, AOutputLength);
   end;
+end;
 
-  if (FRootHashDigest = nil) then
+function TBlake2XS.GetBytesSqueezed: UInt64;
+begin
+  if FReader = nil then
   begin
-    // Get root digest
-    System.SetLength(FRootHashDigest, Blake2SHashSize);
-    TBinaryPrimitives.CopyUInt32LittleEndian(PCardinal(FState), 0, PByte(FRootHashDigest), 0,
-      System.Length(FRootHashDigest));
-  end;
-
-  while AOutputLength > 0 do
+    Result := 0;
+  end
+  else
   begin
-    if (FDigestPosition and (Blake2SHashSize - 1)) = 0 then
-    begin
-      FOutputConfig.Blake2SConfig.HashSize := ComputeStepLength();
-      FOutputConfig.Blake2STreeConfig.InnerHashSize := Blake2SHashSize;
-
-      LHash := TBlake2S.Create(FOutputConfig.Blake2SConfig, FOutputConfig.Blake2STreeConfig);
-      FBlake2XSBuffer := LHash.ComputeBytes(FRootHashDigest).GetBytes();
-      FOutputConfig.Blake2STreeConfig.NodeOffset :=
-        FOutputConfig.Blake2STreeConfig.NodeOffset + 1;
-    end;
-
-    LBlockOffset := FDigestPosition and (Blake2SHashSize - 1);
-
-    LDiff := UInt64(System.Length(FBlake2XSBuffer)) - LBlockOffset;
-
-    // Math.Min
-    if AOutputLength < LDiff then
-    begin
-      LCount := AOutputLength
-    end
-    else
-    begin
-      LCount := LDiff;
-    end;
-
-    System.Move(FBlake2XSBuffer[LBlockOffset],
-      ADestination[ADestinationOffset], LCount);
-
-    System.Dec(AOutputLength, LCount);
-    System.Inc(ADestinationOffset, LCount);
-    System.Inc(FDigestPosition, LCount);
+    Result := FReader.Position;
   end;
 end;
 
@@ -735,7 +871,7 @@ end;
 procedure TBlake2XS.TransformBytes(const AData: THashLibByteArray;
   AIndex, ADataLength: Int32);
 begin
-  if FFinalized then
+  if FReader <> nil then
   begin
     raise EInvalidOperationHashLibException.CreateResFmt
       (@SWritetoXofAfterReadError, [Name]);

--- a/HashLib/src/Crypto/HlpBlake3.pas
+++ b/HashLib/src/Crypto/HlpBlake3.pas
@@ -202,7 +202,7 @@ type
   end;
 
 type
-  TBlake3XOF = class sealed(TBlake3, IXOF)
+  TBlake3XOF = class sealed(TBlake3, IXOF, IXOFStream)
   strict private
   var
     FXOFSizeInBits: UInt64;
@@ -218,6 +218,9 @@ type
     FFinalized: Boolean;
 
     function GetName: String; override;
+    procedure CheckOutputBuffer(const ADestination: THashLibByteArray;
+      ADestinationOffset, AOutputLength: UInt64); inline;
+    procedure EnsureFinalized(); inline;
     property XOFSizeInBits: UInt64 read GetXOFSizeInBits write SetXOFSizeInBits;
 
   public
@@ -236,6 +239,11 @@ type
 
     procedure DoOutput(const ADestination: THashLibByteArray;
       ADestinationOffset, AOutputLength: UInt64);
+
+    procedure Squeeze(const ADestination: THashLibByteArray;
+      ADestinationOffset, AOutputLength: UInt64); overload;
+    function Squeeze(AOutputLength: UInt64): THashLibByteArray; overload;
+    function GetBytesSqueezed: UInt64;
 
   end;
 
@@ -754,10 +762,10 @@ var
 begin
   // Xof Cloning
   LXof := TBlake3XOF.Create(HashSize, nil);
-  LXof.XOFSizeInBits := XOFSizeInBits;
 
   // Blake3XOF Cloning
   LHashInstance := LXof as TBlake3XOF;
+  LHashInstance.FXOFSizeInBits := FXOFSizeInBits;
   LHashInstance.FFinalized := FFinalized;
 
   // Internal Blake3 Cloning
@@ -785,7 +793,7 @@ begin
   FFinalized := False;
 end;
 
-procedure TBlake3XOF.DoOutput(const ADestination: THashLibByteArray;
+procedure TBlake3XOF.CheckOutputBuffer(const ADestination: THashLibByteArray;
   ADestinationOffset, AOutputLength: UInt64);
 begin
   if (UInt64(System.Length(ADestination)) - ADestinationOffset) < AOutputLength
@@ -793,18 +801,53 @@ begin
   begin
     raise EArgumentOutOfRangeHashLibException.CreateRes(@SOutputBufferTooShort);
   end;
+end;
+
+procedure TBlake3XOF.EnsureFinalized();
+begin
+  if not FFinalized then
+  begin
+    Finish();
+    FFinalized := True;
+  end;
+end;
+
+procedure TBlake3XOF.DoOutput(const ADestination: THashLibByteArray;
+  ADestinationOffset, AOutputLength: UInt64);
+begin
+  CheckOutputBuffer(ADestination, ADestinationOffset, AOutputLength);
 
   if ((FOutputReader.Offset + AOutputLength) > (XOFSizeInBits shr 3)) then
   begin
     raise EArgumentOutOfRangeHashLibException.CreateRes(@SOutputLengthInvalid);
   end;
 
-  if not FFinalized then
-  begin
-    Finish();
-    FFinalized := True;
-  end;
+  EnsureFinalized();
   InternalDoOutput(ADestination, ADestinationOffset, AOutputLength);
+end;
+
+procedure TBlake3XOF.Squeeze(const ADestination: THashLibByteArray;
+  ADestinationOffset, AOutputLength: UInt64);
+begin
+  CheckOutputBuffer(ADestination, ADestinationOffset, AOutputLength);
+
+  EnsureFinalized();
+  // no XOFSizeInBits cap; the output reader caps at 2^64-1 bytes
+  InternalDoOutput(ADestination, ADestinationOffset, AOutputLength);
+end;
+
+function TBlake3XOF.Squeeze(AOutputLength: UInt64): THashLibByteArray;
+begin
+  System.SetLength(Result, AOutputLength);
+  if AOutputLength > 0 then
+  begin
+    Squeeze(Result, 0, AOutputLength);
+  end;
+end;
+
+function TBlake3XOF.GetBytesSqueezed: UInt64;
+begin
+  Result := FOutputReader.Offset;
 end;
 
 function TBlake3XOF.GetName: String;

--- a/HashLib/src/Crypto/HlpSHA3.pas
+++ b/HashLib/src/Crypto/HlpSHA3.pas
@@ -142,20 +142,20 @@ type
   end;
 
 type
-  TShake = class abstract(TSHA3, IXOF)
+  TShake = class abstract(TSHA3, IXOF, IXOFStream)
   strict private
-  var
-    FXOFSizeInBits: UInt64;
     function GetXOFSizeInBits: UInt64; inline;
     procedure SetXOFSizeInBits(AXofSizeInBits: UInt64); inline;
     function SetXOFSizeInBitsInternal(AXofSizeInBits: UInt64): IXOF;
   strict protected
   var
-    FBufferPosition, FDigestPosition: UInt64;
-    FShakeBuffer: THashLibByteArray;
-    FFinalized: Boolean;
+    FXOFSizeInBits: UInt64;
+    FReader: IXofReader;
     constructor Create(AHashSize: THashSize);
     function GetHashMode(): TSHA3.THashMode; override;
+    procedure EnsureReader();
+    procedure CheckOutputBuffer(const ADestination: THashLibByteArray;
+      ADestinationOffset, AOutputLength: UInt64); inline;
     property XOFSizeInBits: UInt64 read GetXOFSizeInBits write SetXOFSizeInBits;
 
   public
@@ -166,6 +166,10 @@ type
     function TransformFinal(): IHashResult; override;
     procedure DoOutput(const ADestination: THashLibByteArray;
       ADestinationOffset, AOutputLength: UInt64);
+    procedure Squeeze(const ADestination: THashLibByteArray;
+      ADestinationOffset, AOutputLength: UInt64); overload;
+    function Squeeze(AOutputLength: UInt64): THashLibByteArray; overload;
+    function GetBytesSqueezed: UInt64;
   end;
 
 type
@@ -250,12 +254,18 @@ type
   var
     FHash: IHash;
     FKey: THashLibByteArray;
+    // KMAC appends RightEncode(L) exactly once, immediately before the first
+    // output byte is produced; this guards against re-appending on subsequent
+    // (multi-chunk) DoOutput / Squeeze calls.
+    FRightEncodeAppended: Boolean;
 
     function HashInstanceAsXof: IXOF;
     function GetName: String; override;
 
     function GetKey(): THashLibByteArray;
     procedure SetKey(const AValue: THashLibByteArray);
+
+    procedure EnsureRightEncodeAppended();
 
     procedure DoOutput(const ADestination: THashLibByteArray;
       ADestinationOffset, AOutputLength: UInt64);
@@ -274,6 +284,13 @@ type
     function TransformFinal(): IHashResult; override;
     procedure TransformBytes(const AData: THashLibByteArray;
       AIndex, ALength: Int32); override;
+
+    // IXOFStream (exposed by the KMAC-XOF subclasses): produce an unbounded
+    // stream of output, delegating to the inner cSHAKE stream engine.
+    procedure Squeeze(const ADestination: THashLibByteArray;
+      ADestinationOffset, AOutputLength: UInt64); overload;
+    function Squeeze(AOutputLength: UInt64): THashLibByteArray; overload;
+    function GetBytesSqueezed: UInt64;
 
     property Key: THashLibByteArray read GetKey write SetKey;
     property Name: String read GetName;
@@ -296,7 +313,7 @@ type
   end;
 
 type
-  TKMAC128XOF = class sealed(TKMAC128, IKMAC, IXOF)
+  TKMAC128XOF = class sealed(TKMAC128, IKMAC, IXOF, IXOFStream)
   strict private
 
     function GetXOFSizeInBits: UInt64; inline;
@@ -315,6 +332,8 @@ type
     function Clone(): IHash; override;
     class function CreateKMAC128XOF(const AKMACKey, ACustomization
       : THashLibByteArray; AXofSizeInBits: UInt64): IKMAC; static;
+    class function CreateKMAC128XOFStream(const AKMACKey, ACustomization
+      : THashLibByteArray): IXOFStream; static;
 
   end;
 
@@ -334,7 +353,7 @@ type
   end;
 
 type
-  TKMAC256XOF = class sealed(TKMAC256, IKMAC, IXOF)
+  TKMAC256XOF = class sealed(TKMAC256, IKMAC, IXOF, IXOFStream)
   strict private
 
     function GetXOFSizeInBits: UInt64; inline;
@@ -353,10 +372,105 @@ type
     function Clone(): IHash; override;
     class function CreateKMAC256XOF(const AKMACKey, ACustomization
       : THashLibByteArray; AXofSizeInBits: UInt64): IKMAC; static;
+    class function CreateKMAC256XOFStream(const AKMACKey, ACustomization
+      : THashLibByteArray): IXOFStream; static;
 
   end;
 
 implementation
+
+type
+  // Self-contained SHAKE/Keccak squeeze engine. Owns a copy of the finalized
+  // Keccak state and produces an unbounded byte stream; the size cap (if any)
+  // is enforced by the owning XOF, not here. Shared by SHAKE, CShake and
+  // (via the inner cSHAKE) KMAC-XOF.
+  TKeccakXofReader = class sealed(TInterfacedObject, IXofReader)
+  strict private
+  var
+    FState: THashLibUInt64Array;
+    FShakeBuffer: THashLibByteArray;
+    FBlockSize: Int32;
+    FBufferPosition, FDigestPosition: UInt64;
+  public
+    constructor Create(const AState: THashLibUInt64Array; ABlockSize: Int32);
+    procedure Read(const ADestination: THashLibByteArray;
+      ADestinationOffset, AOutputLength: UInt64);
+    function GetPosition: UInt64;
+    function Clone(): IXofReader;
+  end;
+
+{ TKeccakXofReader }
+
+constructor TKeccakXofReader.Create(const AState: THashLibUInt64Array;
+  ABlockSize: Int32);
+begin
+  inherited Create();
+  FState := System.Copy(AState);
+  System.SetLength(FShakeBuffer, 8);
+  FBlockSize := ABlockSize;
+  FBufferPosition := 0;
+  FDigestPosition := 0;
+end;
+
+function TKeccakXofReader.GetPosition: UInt64;
+begin
+  Result := FDigestPosition;
+end;
+
+procedure TKeccakXofReader.Read(const ADestination: THashLibByteArray;
+  ADestinationOffset, AOutputLength: UInt64);
+var
+  LDiff, LCount, LBlockOffset: UInt64;
+begin
+  while AOutputLength > 0 do
+  begin
+    if (FDigestPosition and 7) = 0 then
+    begin
+
+      if (FBufferPosition * 8) >= UInt64(FBlockSize) then
+      begin
+        KeccakF1600_Permute(@FState[0]);
+        FBufferPosition := 0;
+      end;
+
+      TBinaryPrimitives.WriteUInt64LittleEndian(FShakeBuffer, 0,
+        FState[FBufferPosition]);
+      System.Inc(FBufferPosition);
+    end;
+
+    LBlockOffset := FDigestPosition and 7;
+
+    LDiff := UInt64(System.Length(FShakeBuffer)) - LBlockOffset;
+
+    // Math.Min
+    if AOutputLength < LDiff then
+    begin
+      LCount := AOutputLength
+    end
+    else
+    begin
+      LCount := LDiff;
+    end;
+
+    System.Move(FShakeBuffer[LBlockOffset], ADestination[ADestinationOffset],
+      LCount);
+
+    System.Dec(AOutputLength, LCount);
+    System.Inc(ADestinationOffset, LCount);
+    System.Inc(FDigestPosition, LCount);
+  end;
+end;
+
+function TKeccakXofReader.Clone(): IXofReader;
+var
+  LReader: TKeccakXofReader;
+begin
+  LReader := TKeccakXofReader.Create(FState, FBlockSize);
+  LReader.FShakeBuffer := System.Copy(FShakeBuffer);
+  LReader.FBufferPosition := FBufferPosition;
+  LReader.FDigestPosition := FDigestPosition;
+  Result := LReader;
+end;
 
 { TSHA3 }
 
@@ -652,68 +766,81 @@ end;
 constructor TShake.Create(AHashSize: THashSize);
 begin
   inherited Create(AHashSize);
-  FFinalized := False;
-  System.SetLength(FShakeBuffer, 8);
+  FReader := nil;
 end;
 
-procedure TShake.DoOutput(const ADestination: THashLibByteArray;
-  ADestinationOffset, AOutputLength: UInt64);
-var
-  LDiff, LCount, LBlockOffset: UInt64;
+procedure TShake.EnsureReader();
 begin
+  if FReader = nil then
+  begin
+    Finish();
+    FReader := TKeccakXofReader.Create(FState, BlockSize);
+  end;
+end;
 
+procedure TShake.CheckOutputBuffer(const ADestination: THashLibByteArray;
+  ADestinationOffset, AOutputLength: UInt64);
+begin
   if (UInt64(System.Length(ADestination)) - ADestinationOffset) < AOutputLength
   then
   begin
     raise EArgumentOutOfRangeHashLibException.CreateRes(@SOutputBufferTooShort);
   end;
+end;
 
-  if ((FDigestPosition + AOutputLength) > (XOFSizeInBits shr 3)) then
+procedure TShake.DoOutput(const ADestination: THashLibByteArray;
+  ADestinationOffset, AOutputLength: UInt64);
+var
+  LPosition: UInt64;
+begin
+
+  CheckOutputBuffer(ADestination, ADestinationOffset, AOutputLength);
+
+  if FReader = nil then
+  begin
+    LPosition := 0;
+  end
+  else
+  begin
+    LPosition := FReader.Position;
+  end;
+
+  if ((LPosition + AOutputLength) > (XOFSizeInBits shr 3)) then
   begin
     raise EArgumentOutOfRangeHashLibException.CreateRes(@SOutputLengthInvalid);
   end;
 
-  if not FFinalized then
+  EnsureReader();
+  FReader.Read(ADestination, ADestinationOffset, AOutputLength);
+end;
+
+procedure TShake.Squeeze(const ADestination: THashLibByteArray;
+  ADestinationOffset, AOutputLength: UInt64);
+begin
+  CheckOutputBuffer(ADestination, ADestinationOffset, AOutputLength);
+
+  EnsureReader();
+  FReader.Read(ADestination, ADestinationOffset, AOutputLength);
+end;
+
+function TShake.Squeeze(AOutputLength: UInt64): THashLibByteArray;
+begin
+  System.SetLength(Result, AOutputLength);
+  if AOutputLength > 0 then
   begin
-    Finish();
-    FFinalized := True;
+    Squeeze(Result, 0, AOutputLength);
   end;
+end;
 
-  while AOutputLength > 0 do
+function TShake.GetBytesSqueezed: UInt64;
+begin
+  if FReader = nil then
   begin
-    if (FDigestPosition and 7) = 0 then
-    begin
-
-      if (FBufferPosition * 8) >= UInt64(BlockSize) then
-      begin
-        KeccakF1600_Permute(@FState[0]);
-        FBufferPosition := 0;
-      end;
-
-      TBinaryPrimitives.WriteUInt64LittleEndian(FShakeBuffer, 0, FState[FBufferPosition]);
-      System.Inc(FBufferPosition);
-    end;
-
-    LBlockOffset := FDigestPosition and 7;
-
-    LDiff := UInt64(System.Length(FShakeBuffer)) - LBlockOffset;
-
-    // Math.Min
-    if AOutputLength < LDiff then
-    begin
-      LCount := AOutputLength
-    end
-    else
-    begin
-      LCount := LDiff;
-    end;
-
-    System.Move(FShakeBuffer[LBlockOffset],
-      ADestination[ADestinationOffset], LCount);
-
-    System.Dec(AOutputLength, LCount);
-    System.Inc(ADestinationOffset, LCount);
-    System.Inc(FDigestPosition, LCount);
+    Result := 0;
+  end
+  else
+  begin
+    Result := FReader.Position;
   end;
 end;
 
@@ -731,16 +858,13 @@ end;
 procedure TShake.Initialize;
 begin
   inherited Initialize();
-  FBufferPosition := 0;
-  FDigestPosition := 0;
-  FFinalized := False;
-  TArrayUtils.ZeroFill(FShakeBuffer);
+  FReader := nil;
 end;
 
 procedure TShake.TransformBytes(const AData: THashLibByteArray;
   AIndex, ADataLength: Int32);
 begin
-  if FFinalized then
+  if FReader <> nil then
   begin
     raise EInvalidOperationHashLibException.CreateResFmt
       (@SWritetoXofAfterReadError, [Name]);
@@ -769,14 +893,14 @@ var
 begin
   // Xof Cloning
   LXof := TShake_128.Create();
-  LXof.XOFSizeInBits := Self.XOFSizeInBits;
 
   // Shake_128 Cloning
   LHashInstance := LXof as TShake_128;
-  LHashInstance.FBufferPosition := FBufferPosition;
-  LHashInstance.FDigestPosition := FDigestPosition;
-  LHashInstance.FFinalized := FFinalized;
-  LHashInstance.FShakeBuffer := System.Copy(FShakeBuffer);
+  LHashInstance.FXOFSizeInBits := FXOFSizeInBits;
+  if FReader <> nil then
+  begin
+    LHashInstance.FReader := FReader.Clone();
+  end;
 
   // Internal Sha3 Cloning
   LHashInstance.FBuffer := FBuffer.Clone();
@@ -801,14 +925,14 @@ var
 begin
   // Xof Cloning
   LXof := TShake_256.Create();
-  LXof.XOFSizeInBits := Self.XOFSizeInBits;
 
   // Shake_256 Cloning
   LHashInstance := LXof as TShake_256;
-  LHashInstance.FBufferPosition := FBufferPosition;
-  LHashInstance.FDigestPosition := FDigestPosition;
-  LHashInstance.FFinalized := FFinalized;
-  LHashInstance.FShakeBuffer := System.Copy(FShakeBuffer);
+  LHashInstance.FXOFSizeInBits := FXOFSizeInBits;
+  if FReader <> nil then
+  begin
+    LHashInstance.FReader := FReader.Clone();
+  end;
 
   // Internal Sha3 Cloning
   LHashInstance.FBuffer := FBuffer.Clone();
@@ -947,16 +1071,16 @@ var
 begin
   // Xof Cloning
   LXof := TCShake_128.Create(System.Copy(FN), System.Copy(FS));
-  LXof.XOFSizeInBits := Self.XOFSizeInBits;
 
   // CShake_128 Cloning
   LHashInstance := LXof as TCShake_128;
+  LHashInstance.FXOFSizeInBits := FXOFSizeInBits;
   LHashInstance.FInitBlock := System.Copy(FInitBlock);
 
-  LHashInstance.FBufferPosition := FBufferPosition;
-  LHashInstance.FDigestPosition := FDigestPosition;
-  LHashInstance.FFinalized := FFinalized;
-  LHashInstance.FShakeBuffer := System.Copy(FShakeBuffer);
+  if FReader <> nil then
+  begin
+    LHashInstance.FReader := FReader.Clone();
+  end;
 
   // Internal Sha3 Cloning
   LHashInstance.FBuffer := FBuffer.Clone();
@@ -981,16 +1105,16 @@ var
 begin
   // Xof Cloning
   LXof := TCShake_256.Create(System.Copy(FN), System.Copy(FS));
-  LXof.XOFSizeInBits := Self.XOFSizeInBits;
 
   // CShake_256 Cloning
   LHashInstance := LXof as TCShake_256;
+  LHashInstance.FXOFSizeInBits := FXOFSizeInBits;
   LHashInstance.FInitBlock := System.Copy(FInitBlock);
 
-  LHashInstance.FBufferPosition := FBufferPosition;
-  LHashInstance.FDigestPosition := FDigestPosition;
-  LHashInstance.FFinalized := FFinalized;
-  LHashInstance.FShakeBuffer := System.Copy(FShakeBuffer);
+  if FReader <> nil then
+  begin
+    LHashInstance.FReader := FReader.Clone();
+  end;
 
   // Internal Sha3 Cloning
   LHashInstance.FBuffer := FBuffer.Clone();
@@ -1034,22 +1158,73 @@ begin
   inherited Destroy;
 end;
 
-procedure TKMACNotBuildInAdapter.DoOutput(const ADestination: THashLibByteArray;
-  ADestinationOffset, AOutputLength: UInt64);
+procedure TKMACNotBuildInAdapter.EnsureRightEncodeAppended();
 var
   LXof: IXOF;
 begin
+  if FRightEncodeAppended then
+  begin
+    Exit;
+  end;
+
   LXof := HashInstanceAsXof;
   if Supports(Self, IXOF) then
   begin
+    // KMAC-XOF: arbitrary output length is encoded as RightEncode(0)
     TransformBytes(TCShake.RightEncode(0));
   end
   else
   begin
+    // fixed-length KMAC: the declared output length L (in bits) is encoded
     TransformBytes(TCShake.RightEncode(LXof.XOFSizeInBits));
   end;
 
-  LXof.DoOutput(ADestination, ADestinationOffset, AOutputLength);
+  FRightEncodeAppended := True;
+end;
+
+procedure TKMACNotBuildInAdapter.DoOutput(const ADestination: THashLibByteArray;
+  ADestinationOffset, AOutputLength: UInt64);
+begin
+  EnsureRightEncodeAppended();
+  HashInstanceAsXof.DoOutput(ADestination, ADestinationOffset, AOutputLength);
+end;
+
+procedure TKMACNotBuildInAdapter.Squeeze(const ADestination: THashLibByteArray;
+  ADestinationOffset, AOutputLength: UInt64);
+var
+  LStream: IXOFStream;
+begin
+  EnsureRightEncodeAppended();
+  if not Supports(FHash, IXOFStream, LStream) then
+  begin
+    raise EInvalidOperationHashLibException.Create
+      ('Internal error: KMAC hash must implement IXOFStream');
+  end;
+  LStream.Squeeze(ADestination, ADestinationOffset, AOutputLength);
+end;
+
+function TKMACNotBuildInAdapter.Squeeze(AOutputLength: UInt64)
+  : THashLibByteArray;
+begin
+  System.SetLength(Result, AOutputLength);
+  if AOutputLength > 0 then
+  begin
+    Squeeze(Result, 0, AOutputLength);
+  end;
+end;
+
+function TKMACNotBuildInAdapter.GetBytesSqueezed: UInt64;
+var
+  LStream: IXOFStream;
+begin
+  if Supports(FHash, IXOFStream, LStream) then
+  begin
+    Result := LStream.BytesSqueezed;
+  end
+  else
+  begin
+    Result := 0;
+  end;
 end;
 
 function TKMACNotBuildInAdapter.GetKey: THashLibByteArray;
@@ -1064,6 +1239,7 @@ end;
 
 procedure TKMACNotBuildInAdapter.Initialize;
 begin
+  FRightEncodeAppended := False;
   FHash.Initialize;
   TransformBytes(TCShake.BytePad(TCShake.EncodeString(FKey), BlockSize));
 end;
@@ -1115,6 +1291,7 @@ var
 begin
   LHashInstance := TKMAC128.Create(FHash.Clone(), FKey,
     HashInstanceAsXof.XOFSizeInBits);
+  LHashInstance.FRightEncodeAppended := FRightEncodeAppended;
   Result := LHashInstance;
   Result.BufferSize := BufferSize;
 end;
@@ -1148,7 +1325,7 @@ var
   LXofSizeInBytes: UInt64;
 begin
   LXofSizeInBytes := AXofSizeInBits shr 3;
-  if (((LXofSizeInBytes and $7) <> 0) or (LXofSizeInBytes < 1)) then
+  if (((AXofSizeInBits and $7) <> 0) or (LXofSizeInBytes < 1)) then
   begin
     raise EArgumentInvalidHashLibException.CreateRes(@SInvalidXOFSize);
   end;
@@ -1170,11 +1347,9 @@ end;
 function TKMAC128XOF.Clone(): IHash;
 var
   LHashInstance: TKMAC128XOF;
-  LXof: IXOF;
 begin
   LHashInstance := TKMAC128XOF.Create(FHash.Clone(), FKey);
-  LXof := LHashInstance;
-  LXof.XOFSizeInBits := XOFSizeInBits;
+  LHashInstance.FRightEncodeAppended := FRightEncodeAppended;
   Result := LHashInstance;
   Result.BufferSize := BufferSize;
 end;
@@ -1204,6 +1379,13 @@ begin
   Result := LXof as IKMAC;
 end;
 
+class function TKMAC128XOF.CreateKMAC128XOFStream(const AKMACKey, ACustomization
+  : THashLibByteArray): IXOFStream;
+begin
+  // streaming KMAC-XOF: no output size is declared; Squeeze pulls on demand
+  Result := TKMAC128XOF.Create(AKMACKey, ACustomization) as IXOFStream;
+end;
+
 { TKMAC256 }
 
 function TKMAC256.Clone(): IHash;
@@ -1212,6 +1394,7 @@ var
 begin
   LHashInstance := TKMAC256.Create(FHash.Clone(), FKey,
     HashInstanceAsXof.XOFSizeInBits);
+  LHashInstance.FRightEncodeAppended := FRightEncodeAppended;
   Result := LHashInstance;
   Result.BufferSize := BufferSize;
 end;
@@ -1245,7 +1428,7 @@ var
   LXofSizeInBytes: UInt64;
 begin
   LXofSizeInBytes := AXofSizeInBits shr 3;
-  if (((LXofSizeInBytes and $7) <> 0) or (LXofSizeInBytes < 1)) then
+  if (((AXofSizeInBits and $7) <> 0) or (LXofSizeInBytes < 1)) then
   begin
     raise EArgumentInvalidHashLibException.CreateRes(@SInvalidXOFSize);
   end;
@@ -1267,11 +1450,9 @@ end;
 function TKMAC256XOF.Clone(): IHash;
 var
   LHashInstance: TKMAC256XOF;
-  LXof: IXOF;
 begin
   LHashInstance := TKMAC256XOF.Create(FHash.Clone(), FKey);
-  LXof := LHashInstance;
-  LXof.XOFSizeInBits := XOFSizeInBits;
+  LHashInstance.FRightEncodeAppended := FRightEncodeAppended;
   Result := LHashInstance;
   Result.BufferSize := BufferSize;
 end;
@@ -1299,6 +1480,13 @@ begin
   LXof := TKMAC256XOF.Create(AKMACKey, ACustomization);
   LXof.XOFSizeInBits := AXofSizeInBits;
   Result := LXof as IKMAC;
+end;
+
+class function TKMAC256XOF.CreateKMAC256XOFStream(const AKMACKey, ACustomization
+  : THashLibByteArray): IXOFStream;
+begin
+  // streaming KMAC-XOF: no output size is declared; Squeeze pulls on demand
+  Result := TKMAC256XOF.Create(AKMACKey, ACustomization) as IXOFStream;
 end;
 
 { TKeccak }

--- a/HashLib/src/Interfaces/HlpIHashInfo.pas
+++ b/HashLib/src/Interfaces/HlpIHashInfo.pas
@@ -140,6 +140,49 @@ type
       ADestinationOffset, AOutputLength: UInt64);
   end;
 
+  /// <summary>
+  /// Streaming XOF interface. Unlike <see cref="IXOF" />, the total output
+  /// length need not be declared upfront: <c>Squeeze</c> emits an arbitrary
+  /// number of bytes per call, continuing from where the previous call left
+  /// off. Implemented by the same classes that implement <see cref="IXOF" />.
+  /// </summary>
+  IXOFStream = Interface(IHash)
+    ['{8F2A6C41-3B9E-4D17-A5C8-1E704293B6D0}']
+    /// <summary>
+    /// Squeeze <paramref name="AOutputLength" /> bytes into
+    /// <paramref name="ADestination" /> starting at
+    /// <paramref name="ADestinationOffset" />. No upfront size cap.
+    /// </summary>
+    procedure Squeeze(const ADestination: THashLibByteArray;
+      ADestinationOffset, AOutputLength: UInt64); overload;
+    /// <summary>
+    /// Squeeze and return <paramref name="AOutputLength" /> freshly allocated
+    /// bytes.
+    /// </summary>
+    function Squeeze(AOutputLength: UInt64): THashLibByteArray; overload;
+    function GetBytesSqueezed: UInt64;
+    /// <summary>
+    /// Cumulative number of bytes squeezed since the last
+    /// <c>Initialize</c>.
+    /// </summary>
+    property BytesSqueezed: UInt64 read GetBytesSqueezed;
+  end;
+
+  /// <summary>
+  /// Internal "engine" contract for an XOF squeeze. Owns a self-contained
+  /// copy of the finalized state and produces an unbounded pseudo-random
+  /// byte stream. The size cap (if any) is policy enforced by the owner, not
+  /// by the reader.
+  /// </summary>
+  IXofReader = Interface(IInterface)
+    ['{3D5B9E22-7C14-4A8F-9E6B-2F8A1C0D4E77}']
+    procedure Read(const ADestination: THashLibByteArray;
+      ADestinationOffset, AOutputLength: UInt64);
+    function GetPosition: UInt64;
+    property Position: UInt64 read GetPosition;
+    function Clone(): IXofReader;
+  end;
+
 type
   IArgon2Parameters = interface(IInterface)
     ['{566D3381-57F1-4EE0-81EC-3DB21FF49FBC}']


### PR DESCRIPTION
Core design:
- New IXOFStream (public) and IXofReader (internal "engine") interfaces.
- Extract the squeeze core of each algorithm family into a self-contained IXofReader engine (TKeccakXofReader, TBlake2XSXofReader, TBlake2XBXofReader; Blake3's reader renamed to TBlake3XofReader).
- Each algorithm is now a single class implementing both IXOF and IXOFStream over the shared engine, so DoOutput/Squeeze delegate to one squeeze implementation instead of duplicating it. KMAC fix:
- Fix a latent bug where RightEncode(0) was re-appended on every DoOutput for KMAC-XOF, corrupting multi-chunk output. RightEncode is now applied exactly once per Initialize via EnsureRightEncodeAppended.
- Fix bit-alignment check typo in TKMAC*XOF.SetXOFSizeInBitsInternal ((LXofSizeInBytes and $7) -> (AXofSizeInBits and $7)). Blake2X streaming:
- Unbounded mode is selected via the spec's reserved "unknown length" marker, encapsulated in TBlake2XS.CreateBlake2XSXofStream / TBlake2XB.CreateBlake2XBXofStream so callers never touch the sentinel.