### PR TITLE
refactor(sha): decouple BSWAP masks from SHA round-constant arrays

### DIFF
--- a/HashLib/src/Crypto/HlpSHA1Dispatch.pas
+++ b/HashLib/src/Crypto/HlpSHA1Dispatch.pas
@@ -11,16 +11,23 @@ var
   SHA1_Compress: TSHA1CompressProc;
 
 const
-  // K constants replicated 4x for SIMD, followed by BSWAP32 mask.
-  // Layout: K_00_19 (16B) at 0, K_20_39 at 16, K_40_59 at 32,
-  //   K_60_79 at 48, BSWAP32 mask at 64.
-  K_SHA1: array [0 .. 19] of UInt32 = (
+  // K round constants replicated 4x for SIMD.
+  // Layout: K_00_19 (16B) at 0, K_20_39 at 16, K_40_59 at 32, K_60_79 at 48.
+  K_SHA1: array [0 .. 15] of UInt32 = (
     $5A827999, $5A827999, $5A827999, $5A827999,
     $6ED9EBA1, $6ED9EBA1, $6ED9EBA1, $6ED9EBA1,
     $8F1BBCDC, $8F1BBCDC, $8F1BBCDC, $8F1BBCDC,
-    $CA62C1D6, $CA62C1D6, $CA62C1D6, $CA62C1D6,
+    $CA62C1D6, $CA62C1D6, $CA62C1D6, $CA62C1D6
+  );
+
+{$IFDEF HASHLIB_X86_SIMD}
+  // BSWAP32 shuffle mask for pshufb (x86 SIMD only): reverses bytes within each
+  // dword. Not a SHA-1 constant; passed separately to the SIMD kernels. ARM
+  // byte-swaps with REV32 and needs no mask table.
+  BSWAP32_MASK: array [0 .. 3] of UInt32 = (
     $00010203, $04050607, $08090A0B, $0C0D0E0F
   );
+{$ENDIF HASHLIB_X86_SIMD}
 
 implementation
 
@@ -114,14 +121,14 @@ procedure SHA1_Compress_Sse2(AState, AData: Pointer; ANumBlocks: UInt32);
 end;
 
 procedure SHA1_Compress_Ssse3(AState, AData: Pointer; ANumBlocks: UInt32;
-  AConstants: Pointer);
-  {$I ..\Include\Simd\Common\SimdProc4Begin_i386.inc}
+  AConstants, AMask: Pointer);
+  {$I ..\Include\Simd\Common\SimdProc5Begin_i386.inc}
   {$I ..\Include\Simd\SHA1\SHA1CompressSsse3_i386.inc}
 end;
 
 procedure SHA1_Compress_Ssse3_Wrap(AState, AData: Pointer; ANumBlocks: UInt32);
 begin
-  SHA1_Compress_Ssse3(AState, AData, ANumBlocks, @K_SHA1);
+  SHA1_Compress_Ssse3(AState, AData, ANumBlocks, @K_SHA1, @BSWAP32_MASK);
 end;
 
 {$ENDIF HASHLIB_I386_ASM}
@@ -129,14 +136,14 @@ end;
 {$IFDEF HASHLIB_X86_64_ASM}
 
 procedure SHA1_Compress_ShaNi(AState, AData: Pointer; ANumBlocks: UInt32;
-  AConstants: Pointer);
-  {$I ..\Include\Simd\Common\SimdProc4Begin_x86_64.inc}
+  AConstants, AMask: Pointer);
+  {$I ..\Include\Simd\Common\SimdProc5Begin_x86_64.inc}
   {$I ..\Include\Simd\SHA1\SHA1CompressShaNi_x86_64.inc}
 end;
 
 procedure SHA1_Compress_ShaNi_Wrap(AState, AData: Pointer; ANumBlocks: UInt32);
 begin
-  SHA1_Compress_ShaNi(AState, AData, ANumBlocks, @K_SHA1);
+  SHA1_Compress_ShaNi(AState, AData, ANumBlocks, @K_SHA1, @BSWAP32_MASK);
 end;
 
 procedure SHA1_Compress_Sse2(AState, AData: Pointer; ANumBlocks: UInt32);
@@ -145,25 +152,25 @@ procedure SHA1_Compress_Sse2(AState, AData: Pointer; ANumBlocks: UInt32);
 end;
 
 procedure SHA1_Compress_Ssse3(AState, AData: Pointer; ANumBlocks: UInt32;
-  AConstants: Pointer);
-  {$I ..\Include\Simd\Common\SimdProc4Begin_x86_64.inc}
+  AConstants, AMask: Pointer);
+  {$I ..\Include\Simd\Common\SimdProc5Begin_x86_64.inc}
   {$I ..\Include\Simd\SHA1\SHA1CompressSsse3_x86_64.inc}
 end;
 
 procedure SHA1_Compress_Ssse3_Wrap(AState, AData: Pointer; ANumBlocks: UInt32);
 begin
-  SHA1_Compress_Ssse3(AState, AData, ANumBlocks, @K_SHA1);
+  SHA1_Compress_Ssse3(AState, AData, ANumBlocks, @K_SHA1, @BSWAP32_MASK);
 end;
 
 procedure SHA1_Compress_Avx2(AState, AData: Pointer; ANumBlocks: UInt32;
-  AConstants: Pointer);
-  {$I ..\Include\Simd\Common\SimdProc4Begin_x86_64.inc}
+  AConstants, AMask: Pointer);
+  {$I ..\Include\Simd\Common\SimdProc5Begin_x86_64.inc}
   {$I ..\Include\Simd\SHA1\SHA1CompressAvx2_x86_64.inc}
 end;
 
 procedure SHA1_Compress_Avx2_Wrap(AState, AData: Pointer; ANumBlocks: UInt32);
 begin
-  SHA1_Compress_Avx2(AState, AData, ANumBlocks, @K_SHA1);
+  SHA1_Compress_Avx2(AState, AData, ANumBlocks, @K_SHA1, @BSWAP32_MASK);
 end;
 
 {$ENDIF HASHLIB_X86_64_ASM}

--- a/HashLib/src/Crypto/HlpSHA2_256Dispatch.pas
+++ b/HashLib/src/Crypto/HlpSHA2_256Dispatch.pas
@@ -12,8 +12,7 @@ var
 
 const
   // K256 round constants (64 UInt32 = 256 bytes)
-  // followed by BSWAP32 mask for pshufb (4 UInt32 = 16 bytes) at offset 256
-  K256: array [0 .. 67] of UInt32 = (
+  K256: array [0 .. 63] of UInt32 = (
     $428A2F98, $71374491, $B5C0FBCF, $E9B5DBA5,
     $3956C25B, $59F111F1, $923F82A4, $AB1C5ED5,
     $D807AA98, $12835B01, $243185BE, $550C7DC3,
@@ -29,10 +28,17 @@ const
     $19A4C116, $1E376C08, $2748774C, $34B0BCB5,
     $391C0CB3, $4ED8AA4A, $5B9CCA4F, $682E6FF3,
     $748F82EE, $78A5636F, $84C87814, $8CC70208,
-    $90BEFFFA, $A4506CEB, $BEF9A3F7, $C67178F2,
-    // BSWAP32 mask at offset 256: reverses bytes within each dword
+    $90BEFFFA, $A4506CEB, $BEF9A3F7, $C67178F2
+  );
+
+{$IFDEF HASHLIB_X86_SIMD}
+  // BSWAP32 shuffle mask for pshufb (x86 SIMD only): reverses bytes within each
+  // dword. Not a SHA-256 constant; passed separately to the SIMD kernels. ARM
+  // byte-swaps with REV32 and needs no mask table.
+  BSWAP32_MASK: array [0 .. 3] of UInt32 = (
     $00010203, $04050607, $08090A0B, $0C0D0E0F
   );
+{$ENDIF HASHLIB_X86_SIMD}
 
 implementation
 
@@ -110,8 +116,8 @@ procedure SHA256_Compress_Sse2(AState, AData: Pointer; ANumBlocks: UInt32;
 end;
 
 procedure SHA256_Compress_Ssse3(AState, AData: Pointer; ANumBlocks: UInt32;
-  AConstants: Pointer);
-  {$I ..\Include\Simd\Common\SimdProc4Begin_i386.inc}
+  AConstants, AMask: Pointer);
+  {$I ..\Include\Simd\Common\SimdProc5Begin_i386.inc}
   {$I ..\Include\Simd\SHA256\SHA256CompressSsse3_i386.inc}
 end;
 
@@ -120,14 +126,14 @@ end;
 {$IFDEF HASHLIB_X86_64_ASM}
 
 procedure SHA256_Compress_ShaNi(AState, AData: Pointer; ANumBlocks: UInt32;
-  AConstants: Pointer);
-  {$I ..\Include\Simd\Common\SimdProc4Begin_x86_64.inc}
+  AConstants, AMask: Pointer);
+  {$I ..\Include\Simd\Common\SimdProc5Begin_x86_64.inc}
   {$I ..\Include\Simd\SHA256\SHA256CompressShaNi_x86_64.inc}
 end;
 
 procedure SHA256_Compress_ShaNi_Wrap(AState, AData: Pointer; ANumBlocks: UInt32);
 begin
-  SHA256_Compress_ShaNi(AState, AData, ANumBlocks, @K256);
+  SHA256_Compress_ShaNi(AState, AData, ANumBlocks, @K256, @BSWAP32_MASK);
 end;
 
 procedure SHA256_Compress_Sse2(AState, AData: Pointer; ANumBlocks: UInt32;
@@ -137,25 +143,25 @@ procedure SHA256_Compress_Sse2(AState, AData: Pointer; ANumBlocks: UInt32;
 end;
 
 procedure SHA256_Compress_Ssse3(AState, AData: Pointer; ANumBlocks: UInt32;
-  AConstants: Pointer);
-  {$I ..\Include\Simd\Common\SimdProc4Begin_x86_64.inc}
+  AConstants, AMask: Pointer);
+  {$I ..\Include\Simd\Common\SimdProc5Begin_x86_64.inc}
   {$I ..\Include\Simd\SHA256\SHA256CompressSsse3_x86_64.inc}
 end;
 
 procedure SHA256_Compress_Ssse3_Wrap(AState, AData: Pointer; ANumBlocks: UInt32);
 begin
-  SHA256_Compress_Ssse3(AState, AData, ANumBlocks, @K256);
+  SHA256_Compress_Ssse3(AState, AData, ANumBlocks, @K256, @BSWAP32_MASK);
 end;
 
 procedure SHA256_Compress_Avx2(AState, AData: Pointer; ANumBlocks: UInt32;
-  AConstants: Pointer);
-  {$I ..\Include\Simd\Common\SimdProc4Begin_x86_64.inc}
+  AConstants, AMask: Pointer);
+  {$I ..\Include\Simd\Common\SimdProc5Begin_x86_64.inc}
   {$I ..\Include\Simd\SHA256\SHA256CompressAvx2_x86_64.inc}
 end;
 
 procedure SHA256_Compress_Avx2_Wrap(AState, AData: Pointer; ANumBlocks: UInt32);
 begin
-  SHA256_Compress_Avx2(AState, AData, ANumBlocks, @K256);
+  SHA256_Compress_Avx2(AState, AData, ANumBlocks, @K256, @BSWAP32_MASK);
 end;
 
 {$ENDIF HASHLIB_X86_64_ASM}
@@ -171,7 +177,7 @@ end;
 
 procedure SHA256_Compress_Ssse3_Wrap(AState, AData: Pointer; ANumBlocks: UInt32);
 begin
-  SHA256_Compress_Ssse3(AState, AData, ANumBlocks, @K256);
+  SHA256_Compress_Ssse3(AState, AData, ANumBlocks, @K256, @BSWAP32_MASK);
 end;
 
 {$ENDIF HASHLIB_I386_ASM}

--- a/HashLib/src/Crypto/HlpSHA2_512Dispatch.pas
+++ b/HashLib/src/Crypto/HlpSHA2_512Dispatch.pas
@@ -12,8 +12,7 @@ var
 
 const
   // K512 round constants (80 UInt64 = 640 bytes)
-  // followed by BSWAP64 mask (2 UInt64 = 16 bytes) at offset 640
-  K512: array [0 .. 81] of UInt64 = (
+  K512: array [0 .. 79] of UInt64 = (
     UInt64($428A2F98D728AE22), UInt64($7137449123EF65CD),
     UInt64($B5C0FBCFEC4D3B2F), UInt64($E9B5DBA58189DBBC),
     UInt64($3956C25BF348B538), UInt64($59F111F1B605D019),
@@ -53,10 +52,17 @@ const
     UInt64($28DB77F523047D84), UInt64($32CAAB7B40C72493),
     UInt64($3C9EBE0A15C9BEBC), UInt64($431D67C49C100D4C),
     UInt64($4CC5D4BECB3E42B6), UInt64($597F299CFC657E2A),
-    UInt64($5FCB6FAB3AD6FAEC), UInt64($6C44198C4A475817),
-    // BSWAP64 mask at offset 640: reverses bytes within each qword
+    UInt64($5FCB6FAB3AD6FAEC), UInt64($6C44198C4A475817)
+  );
+
+{$IFDEF HASHLIB_X86_SIMD}
+  // BSWAP64 shuffle mask for pshufb (x86 SIMD only): reverses bytes within each
+  // qword. Not a SHA-512 constant; passed separately to the SIMD kernels. ARM
+  // byte-swaps with REV64 and needs no mask table.
+  BSWAP64_MASK: array [0 .. 1] of UInt64 = (
     UInt64($0001020304050607), UInt64($08090A0B0C0D0E0F)
   );
+{$ENDIF HASHLIB_X86_SIMD}
 
 implementation
 
@@ -134,14 +140,14 @@ procedure SHA512_Compress_Sse2(AState, AData: Pointer; ANumBlocks: UInt32;
 end;
 
 procedure SHA512_Compress_Ssse3(AState, AData: Pointer; ANumBlocks: UInt32;
-  AConstants: Pointer);
-  {$I ..\Include\Simd\Common\SimdProc4Begin_i386.inc}
+  AConstants, AMask: Pointer);
+  {$I ..\Include\Simd\Common\SimdProc5Begin_i386.inc}
   {$I ..\Include\Simd\SHA512\SHA512CompressSsse3_i386.inc}
 end;
 
 procedure SHA512_Compress_Ssse3_Wrap(AState, AData: Pointer; ANumBlocks: UInt32);
 begin
-  SHA512_Compress_Ssse3(AState, AData, ANumBlocks, @K512);
+  SHA512_Compress_Ssse3(AState, AData, ANumBlocks, @K512, @BSWAP64_MASK);
 end;
 
 {$ENDIF HASHLIB_I386_ASM}
@@ -155,25 +161,25 @@ procedure SHA512_Compress_Sse2(AState, AData: Pointer; ANumBlocks: UInt32;
 end;
 
 procedure SHA512_Compress_Ssse3(AState, AData: Pointer; ANumBlocks: UInt32;
-  AConstants: Pointer);
-  {$I ..\Include\Simd\Common\SimdProc4Begin_x86_64.inc}
+  AConstants, AMask: Pointer);
+  {$I ..\Include\Simd\Common\SimdProc5Begin_x86_64.inc}
   {$I ..\Include\Simd\SHA512\SHA512CompressSsse3_x86_64.inc}
 end;
 
 procedure SHA512_Compress_Ssse3_Wrap(AState, AData: Pointer; ANumBlocks: UInt32);
 begin
-  SHA512_Compress_Ssse3(AState, AData, ANumBlocks, @K512);
+  SHA512_Compress_Ssse3(AState, AData, ANumBlocks, @K512, @BSWAP64_MASK);
 end;
 
 procedure SHA512_Compress_Avx2(AState, AData: Pointer; ANumBlocks: UInt32;
-  AConstants: Pointer);
-  {$I ..\Include\Simd\Common\SimdProc4Begin_x86_64.inc}
+  AConstants, AMask: Pointer);
+  {$I ..\Include\Simd\Common\SimdProc5Begin_x86_64.inc}
   {$I ..\Include\Simd\SHA512\SHA512CompressAvx2_x86_64.inc}
 end;
 
 procedure SHA512_Compress_Avx2_Wrap(AState, AData: Pointer; ANumBlocks: UInt32);
 begin
-  SHA512_Compress_Avx2(AState, AData, ANumBlocks, @K512);
+  SHA512_Compress_Avx2(AState, AData, ANumBlocks, @K512, @BSWAP64_MASK);
 end;
 
 {$ENDIF HASHLIB_X86_64_ASM}

--- a/HashLib/src/Include/Simd/SHA1/SHA1CompressAvx2_x86_64.inc
+++ b/HashLib/src/Include/Simd/SHA1/SHA1CompressAvx2_x86_64.inc
@@ -3,9 +3,9 @@
 // Same algorithm as SSSE3 but using VEX-encoded instructions for the byte-swap phase,
 // avoiding SSE/AVX transition penalties on Sandy Bridge/Ivy Bridge.
 // AVX/AVX2 instructions are db-encoded for broad assembler compatibility.
-// Expects MS x64 ABI: rcx = state ptr, rdx = data ptr, r8d = numblocks, r9 = K_SHA1 ptr.
-// K_SHA1 layout: K_00_19 (16 bytes) at offset 0, K_20_39 at 16, K_40_59 at 32,
-//   K_60_79 at 48, BSWAP32 mask (16 bytes) at offset 64.
+// Expects MS x64 ABI: rcx = state ptr, rdx = data ptr, r8d = numblocks,
+//   r9 = K_SHA1 ptr (K_00_19 at 0, K_20_39 at 16, K_40_59 at 32, K_60_79 at 48),
+//   r10 = BSWAP32 mask ptr (16 bytes).
 //
 // Two phases per block:
 //   Phase 1 (SIMD): VEX byte-swap W[0..15] via vpshufb, then expand W[16..79]
@@ -31,6 +31,7 @@
   mov r13, rdx
   mov r14d, r8d
   mov [rsp + $60], r9
+  mov [rsp + $68], r10
 
   test r14d, r14d
   jz @avx2_sha1_done
@@ -39,8 +40,9 @@
 
   // ========== Phase 1: SIMD message schedule ==========
 
+  mov rax, [rsp + $68]
+  db $C5, $FA, $6F, $38                         // vmovdqu xmm7, oword [rax]
   mov rax, [rsp + $60]
-  db $C5, $FA, $6F, $78, $40                    // vmovdqu xmm7, oword [rax + $40]
 
   lea r15, [rsp + $70]
 

--- a/HashLib/src/Include/Simd/SHA1/SHA1CompressShaNi_x86_64.inc
+++ b/HashLib/src/Include/Simd/SHA1/SHA1CompressShaNi_x86_64.inc
@@ -1,7 +1,7 @@
 // SHA-1 SHA-NI implementation.
-// Expects MS x64 ABI: rcx = state ptr, rdx = data ptr, r8d = numblocks, r9 = K_SHA1 ptr.
-// K_SHA1 layout: K_00_19 at 0, K_20_39 at 16, K_40_59 at 32,
-//   K_60_79 at 48, BSWAP32 mask (16 bytes) at offset 64.
+// Expects MS x64 ABI: rcx = state ptr, rdx = data ptr, r8d = numblocks,
+//   r9 = K_SHA1 ptr (unused here: sha1rnds4 has the round constants built in),
+//   r10 = BSWAP32 mask ptr (16 bytes).
 // Uses xmm0-xmm8; xmm6-xmm8 are MS x64 non-volatile (saved/restored).
 // Reference: Intel SHA Extensions whitepaper.
 //
@@ -44,7 +44,7 @@
   // Load, byte-swap, and reverse dword order for all 4 message blocks.
   // The per-dword BSWAP mask puts W[0] at [31:0], but sha1rnds4 reads
   // W[0] from [127:96]. The pshufd $1B reverses the dword order.
-  movdqu xmm7, oword [r9 + $40]    // BSWAP mask at offset 64
+  movdqu xmm7, oword [r10]         // BSWAP32 mask (separate ptr)
   movdqu xmm3, oword [rdx]
   pshufb xmm3, xmm7
   pshufd xmm3, xmm3, $1B

--- a/HashLib/src/Include/Simd/SHA1/SHA1CompressSse2_i386.inc
+++ b/HashLib/src/Include/Simd/SHA1/SHA1CompressSse2_i386.inc
@@ -3,7 +3,8 @@
 // Same algorithm as SSSE3 version but byte-swap uses SSE2 emulation
 //   (pshuflw/pshufhw + psrlw/psllw/por) instead of SSSE3 pshufb.
 // IA-32: after SimdProc3Begin_i386 — ebx = state, esi = data, edi = numblocks
-//   (parallel to MS x64 ABI: rcx, rdx, r8d; K constants are inlined here — x64 SSE2 passes K_SHA1 via r9).
+//   (parallel to MS x64 ABI: rcx, rdx, r8d). Round constants are inlined as
+//   immediates and SSE2 byte-swaps without a mask (both x64 and i386 use 3 params).
 // Uses xmm0–xmm6; xmm6 saved/restored defensively (volatile on i386).
 //
 // Two phases per block:

--- a/HashLib/src/Include/Simd/SHA1/SHA1CompressSse2_x86_64.inc
+++ b/HashLib/src/Include/Simd/SHA1/SHA1CompressSse2_x86_64.inc
@@ -2,9 +2,9 @@
 // Based on SSSE3 implementation (see SHA1CompressSsse3_x86_64.inc).
 // Same algorithm as SSSE3 version but byte-swap uses SSE2 emulation
 // (pshuflw/pshufhw + psrlw/psllw/por) instead of SSSE3 pshufb.
-// Expects MS x64 ABI: rcx = state ptr, rdx = data ptr, r8d = numblocks, r9 = K_SHA1 ptr.
-// K_SHA1 layout: K_00_19 (16 bytes) at offset 0, K_20_39 at 16, K_40_59 at 32,
-//   K_60_79 at 48, BSWAP32 mask (16 bytes) at offset 64.
+// Expects MS x64 ABI: rcx = state ptr, rdx = data ptr, r8d = numblocks (3-param path).
+// Round constants are inlined as immediates and SSE2 byte-swaps without a mask, so
+// neither a K_SHA1 ptr nor a BSWAP mask ptr is passed.
 // Uses xmm0-xmm6, all GPR.
 //
 // Two phases per block:

--- a/HashLib/src/Include/Simd/SHA1/SHA1CompressSsse3_i386.inc
+++ b/HashLib/src/Include/Simd/SHA1/SHA1CompressSsse3_i386.inc
@@ -1,6 +1,7 @@
 // SHA-1 SSSE3 implementation with SIMD message schedule (IA-32).
-// After SimdProc4Begin_i386 — ebx = state, esi = data, edi = numblocks, eax = K_SHA1 ptr.
-// K_SHA1 layout matches x64: K_00_19..K_60_79 (64B), BSWAP32 mask at offset 64 ($40).
+// After SimdProc5Begin_i386 — ebx = state, esi = data, edi = numblocks,
+//   eax = K_SHA1 ptr (unused: Phase 2 uses immediate round constants),
+//   ecx = BSWAP32 mask ptr (16 bytes). maskptr saved to [esp+$3C], reloaded each block.
 // Phase 1 matches SHA1CompressSsse3_x86_64.inc (pshufb + same expand); Phase 2 matches SSE2 i386 GPR rounds.
 // Uses xmm0–xmm7 in Phase 1; xmm7 = BSWAP mask.
 // xmm6–xmm7 saved/restored defensively (volatile on i386).
@@ -22,6 +23,7 @@
   mov [esp + $18], edi
   mov [esp + $34], eax
   mov [esp + $38], ebp
+  mov [esp + $3C], ecx
 
   test edi, edi
   jz @ssse3_sha1_done
@@ -30,8 +32,8 @@
 
   // ========== Phase 1: SIMD message schedule ==========
 
-  mov eax, [esp + $34]
-  movdqu xmm7, oword ptr [eax + $40]
+  mov eax, [esp + $3C]
+  movdqu xmm7, oword ptr [eax]
   mov esi, [esp + $14]
   lea ebx, [esp + $60]
 

--- a/HashLib/src/Include/Simd/SHA1/SHA1CompressSsse3_x86_64.inc
+++ b/HashLib/src/Include/Simd/SHA1/SHA1CompressSsse3_x86_64.inc
@@ -1,9 +1,9 @@
 // SHA-1 SSSE3 implementation with SIMD message schedule.
 // Inspired by OpenSSL sha1-x86_64.pl by Andy Polyakov (CRYPTOGAMS),
 // Linux kernel sha1_ssse3_asm.S by Maxim Locktyukhin / Ronen Zohar / Mathias Krause.
-// Expects MS x64 ABI: rcx = state ptr, rdx = data ptr, r8d = numblocks, r9 = K_SHA1 ptr.
-// K_SHA1 layout: K_00_19 (16 bytes) at offset 0, K_20_39 at 16, K_40_59 at 32,
-//   K_60_79 at 48, BSWAP32 mask (16 bytes) at offset 64.
+// Expects MS x64 ABI: rcx = state ptr, rdx = data ptr, r8d = numblocks,
+//   r9 = K_SHA1 ptr (K_00_19 at 0, K_20_39 at 16, K_40_59 at 32, K_60_79 at 48),
+//   r10 = BSWAP32 mask ptr (16 bytes).
 // Uses xmm0-xmm7 (SIMD message schedule + byte-swap), all GPR.
 //
 // Two phases per block:
@@ -27,7 +27,7 @@
 //   [rsp +  80.. 87]: r14 save
 //   [rsp +  88.. 95]: r15 save
 //   [rsp +  96..103]: K_SHA1 ptr save
-//   [rsp + 104..111]: padding
+//   [rsp + 104..111]: BSWAP mask ptr save
 //   [rsp + 112..431]: W buffer (320 bytes = 80 x 4, 16-byte aligned)
 
   sub rsp, 440
@@ -47,6 +47,7 @@
   mov r13, rdx
   mov r14d, r8d
   mov [rsp + $60], r9
+  mov [rsp + $68], r10
 
   test r14d, r14d
   jz @ssse3_sha1_done
@@ -55,8 +56,9 @@
 
   // ========== Phase 1: SIMD message schedule ==========
 
+  mov rax, [rsp + $68]
+  movdqu xmm7, oword [rax]
   mov rax, [rsp + $60]
-  movdqu xmm7, oword [rax + $40]
 
   lea r15, [rsp + $70]
 

--- a/HashLib/src/Include/Simd/SHA256/SHA256CompressAvx2_x86_64.inc
+++ b/HashLib/src/Include/Simd/SHA256/SHA256CompressAvx2_x86_64.inc
@@ -2,8 +2,8 @@
 // Same algorithm as SSSE3 but using VEX-encoded instructions for 3-operand
 // non-destructive forms, shorter encoding, and no SSE/AVX transition penalties.
 // AVX/AVX2 instructions are db-encoded for broad assembler compatibility.
-// Expects MS x64 ABI: rcx = state ptr, rdx = data ptr, r8d = numblocks, r9 = K256 ptr.
-// K256 layout: 64 UInt32 round constants (256 bytes), then BSWAP mask (16 bytes) at offset 256.
+// Expects MS x64 ABI: rcx = state ptr, rdx = data ptr, r8d = numblocks,
+//   r9 = K256 ptr (64 UInt32 round constants), r10 = BSWAP32 mask ptr (16 bytes).
 //
 // Two-phase per block:
 //   Phase 1 (VEX-128 SIMD): Compute W+K[0..63] using message schedule, store to stack
@@ -23,7 +23,7 @@
 //   [rsp +  80.. 87]: r14 save
 //   [rsp +  88.. 95]: r15 save
 //   [rsp +  96..103]: K256 ptr save
-//   [rsp + 104..111]: padding
+//   [rsp + 104..111]: BSWAP mask ptr save
 //   [rsp + 112..367]: W+K buffer (256 bytes, 16-byte aligned)
 
   sub rsp, 376
@@ -43,6 +43,7 @@
   mov r13, rdx
   mov r14d, r8d
   mov [rsp + $60], r9
+  mov [rsp + $68], r10
 
   test r14d, r14d
   jz @avx2_done
@@ -51,8 +52,9 @@
 
   // ========== Phase 1: Message Schedule (VEX-128) ==========
 
+  mov rax, [rsp + $68]
+  db $C5, $FA, $6F, $38                         // vmovdqu xmm7, oword [rax]
   mov rax, [rsp + $60]
-  db $C5, $FA, $6F, $B8, $00, $01, $00, $00     // vmovdqu xmm7, oword [rax + $100]
 
   db $C4, $C1, $7A, $6F, $45, $00               // vmovdqu xmm0, oword [r13]
   db $C4, $E2, $79, $00, $C7                    // vpshufb xmm0, xmm0, xmm7

--- a/HashLib/src/Include/Simd/SHA256/SHA256CompressShaNi_x86_64.inc
+++ b/HashLib/src/Include/Simd/SHA256/SHA256CompressShaNi_x86_64.inc
@@ -1,6 +1,6 @@
 // SHA-256 SHA-NI implementation.
-// Expects MS x64 ABI: rcx = state ptr, rdx = data ptr, r8d = numblocks, r9 = K256 ptr.
-// K256 layout: 64 UInt32 round constants (256 bytes), then BSWAP mask (16 bytes) at offset 256.
+// Expects MS x64 ABI: rcx = state ptr, rdx = data ptr, r8d = numblocks,
+//   r9 = K256 ptr (64 UInt32 round constants), r10 = BSWAP32 mask ptr (16 bytes).
 // Uses xmm0-xmm9; xmm6-xmm9 are MS x64 non-volatile (saved/restored).
 // Reference: Jeffrey Walton / Sean Gulley / Intel SHA Extensions whitepaper.
 //
@@ -46,7 +46,7 @@
   movdqa xmm9, xmm2
 
   // Load and byte-swap all 4 message blocks
-  movdqu xmm7, oword [r9 + $100]        // BSWAP mask at offset 256
+  movdqu xmm7, oword [r10]              // BSWAP32 mask (separate ptr)
   movdqu xmm3, oword [rdx]
   pshufb xmm3, xmm7
   movdqu xmm4, oword [rdx + $10]

--- a/HashLib/src/Include/Simd/SHA256/SHA256CompressSse2_i386.inc
+++ b/HashLib/src/Include/Simd/SHA256/SHA256CompressSse2_i386.inc
@@ -5,7 +5,8 @@
 //   palignr -> SSE2 emulation (movdqa/psrldq/pslldq/por)
 // IA-32: after SimdProc4Begin_i386 — ebx = state, esi = data, edi = numblocks, eax = K256 ptr
 //   (parallel to MS x64 ABI: rcx, rdx, r8d, r9).
-// K256 layout: 64 UInt32 round constants (256 bytes), then BSWAP mask (16 bytes) at offset 256.
+// K256: 64 UInt32 round constants (256 bytes). SSE2 byte-swaps without a mask, so
+// no BSWAP mask ptr is needed (4-param path).
 // Uses xmm0–xmm7; xmm6–xmm7 saved/restored defensively (volatile on i386).
 //
 // Two-phase per block:

--- a/HashLib/src/Include/Simd/SHA256/SHA256CompressSse2_x86_64.inc
+++ b/HashLib/src/Include/Simd/SHA256/SHA256CompressSse2_x86_64.inc
@@ -4,7 +4,8 @@
 //   pshufb  -> SSE2 byte-swap (pshuflw/pshufhw + psrlw/psllw/por)
 //   palignr -> SSE2 emulation (movdqa/psrldq/pslldq/por)
 // Expects MS x64 ABI: rcx = state ptr, rdx = data ptr, r8d = numblocks, r9 = K256 ptr.
-// K256 layout: 64 UInt32 round constants (256 bytes), then BSWAP mask (16 bytes) at offset 256.
+// K256: 64 UInt32 round constants (256 bytes). SSE2 byte-swaps without a mask, so
+// no BSWAP mask ptr is needed (4-param path).
 // Uses xmm0-xmm7, all GPR.
 //
 // Two-phase per block:

--- a/HashLib/src/Include/Simd/SHA256/SHA256CompressSsse3_i386.inc
+++ b/HashLib/src/Include/Simd/SHA256/SHA256CompressSsse3_i386.inc
@@ -1,7 +1,8 @@
 // SHA-256 SSSE3 implementation with SIMD message schedule (IA-32).
-// After SimdProc4Begin_i386 — ebx = state, esi = data, edi = numblocks, eax = K256 ptr.
+// After SimdProc5Begin_i386 — ebx = state, esi = data, edi = numblocks,
+//   eax = K256 ptr (64 UInt32 round constants), ecx = BSWAP32 mask ptr (16 bytes).
 // Phase 1 matches SHA256CompressSsse3_x86_64.inc (pshufb, palignr); Phase 2 same GPR rounds as SSE2 i386.
-// K256 layout: 64 UInt32 round constants (256 bytes), then BSWAP mask (16 bytes) at offset 256.
+// maskptr is saved to [esp+$48] in the prologue and reloaded (into eax) each block.
 // Uses xmm0–xmm7; xmm6–xmm7 saved/restored defensively (volatile on i386).
 //
 // Two-phase per block:
@@ -20,6 +21,7 @@
   mov [esp + $28], edi
   mov [esp + $2C], eax
   mov [esp + $30], ebp
+  mov [esp + $48], ecx
 
   test edi, edi
   jz @ssse3_256_done
@@ -32,7 +34,8 @@
   mov esi, [esp + $24]
   lea ebp, [esp + $70]
 
-  movdqu xmm7, oword ptr [ebx + $100]
+  mov eax, [esp + $48]
+  movdqu xmm7, oword ptr [eax]
   movdqu xmm0, oword ptr [esi]
   pshufb xmm0, xmm7
   movdqu xmm1, oword ptr [esi + $10]

--- a/HashLib/src/Include/Simd/SHA256/SHA256CompressSsse3_x86_64.inc
+++ b/HashLib/src/Include/Simd/SHA256/SHA256CompressSsse3_x86_64.inc
@@ -1,6 +1,6 @@
 // SHA-256 SSSE3 implementation with SIMD message schedule.
-// Expects MS x64 ABI: rcx = state ptr, rdx = data ptr, r8d = numblocks, r9 = K256 ptr.
-// K256 layout: 64 UInt32 round constants (256 bytes), then BSWAP mask (16 bytes) at offset 256.
+// Expects MS x64 ABI: rcx = state ptr, rdx = data ptr, r8d = numblocks,
+//   r9 = K256 ptr (64 UInt32 round constants), r10 = BSWAP32 mask ptr (16 bytes).
 // Uses xmm0-xmm7, all GPR.
 //
 // Two-phase per block:
@@ -21,7 +21,7 @@
 //   [rsp +  80.. 87]: r14 save
 //   [rsp +  88.. 95]: r15 save
 //   [rsp +  96..103]: K256 ptr save
-//   [rsp + 104..111]: padding
+//   [rsp + 104..111]: BSWAP mask ptr save
 //   [rsp + 112..367]: W+K buffer (256 bytes, 16-byte aligned)
 
   sub rsp, 376
@@ -41,6 +41,7 @@
   mov r13, rdx
   mov r14d, r8d
   mov [rsp + $60], r9
+  mov [rsp + $68], r10
 
   test r14d, r14d
   jz @ssse3_done
@@ -49,8 +50,9 @@
 
   // ========== Phase 1: Message Schedule ==========
 
+  mov rax, [rsp + $68]
+  movdqu xmm7, oword [rax]
   mov rax, [rsp + $60]
-  movdqu xmm7, oword [rax + $100]
 
   movdqu xmm0, oword [r13]
   pshufb xmm0, xmm7

--- a/HashLib/src/Include/Simd/SHA512/SHA512CompressAvx2_x86_64.inc
+++ b/HashLib/src/Include/Simd/SHA512/SHA512CompressAvx2_x86_64.inc
@@ -2,8 +2,8 @@
 // Same algorithm as SSSE3 but using VEX-encoded instructions for the initial
 // byte-swap and K addition. Eliminates SSE/AVX transition penalties.
 // AVX/AVX2 instructions are db-encoded for broad assembler compatibility.
-// Expects MS x64 ABI: rcx = state ptr, rdx = data ptr, r8d = numblocks, r9 = K512 ptr.
-// K512 layout: 80 UInt64 round constants (640 bytes), then BSWAP64 mask (16 bytes) at offset 640.
+// Expects MS x64 ABI: rcx = state ptr, rdx = data ptr, r8d = numblocks,
+//   r9 = K512 ptr (80 UInt64 round constants), r10 = BSWAP64 mask ptr (16 bytes).
 //
 // MS x64 non-volatile saves: xmm6-xmm7, rbx, rbp, rdi, rsi, r12-r15.
 //
@@ -19,7 +19,7 @@
 //   [rsp +  80.. 87]: r14 save
 //   [rsp +  88.. 95]: r15 save
 //   [rsp +  96..103]: K512 ptr save
-//   [rsp + 104..111]: padding
+//   [rsp + 104..111]: BSWAP mask ptr save
 //   [rsp + 112..751]: W+K buffer (640 bytes = 80 * 8, 16-byte aligned)
 //   [rsp + 752..879]: W circular buffer (128 bytes = 16 * 8)
 
@@ -40,6 +40,7 @@
   mov r13, rdx
   mov r14d, r8d
   mov [rsp + $60], r9
+  mov [rsp + $68], r10
 
   test r14d, r14d
   jz @avx2_512_done
@@ -48,8 +49,9 @@
 
   // ========== Phase 1: Load, byte-swap (VEX), expand ==========
 
+  mov rax, [rsp + $68]
+  db $C5, $FA, $6F, $38                         // vmovdqu xmm7, oword [rax]
   mov rax, [rsp + $60]
-  db $C5, $FA, $6F, $B8, $80, $02, $00, $00     // vmovdqu xmm7, oword [rax + $280]
 
   lea rbp, [rsp + $70]
   lea r15, [rsp + $2F0]

--- a/HashLib/src/Include/Simd/SHA512/SHA512CompressSse2_x86_64.inc
+++ b/HashLib/src/Include/Simd/SHA512/SHA512CompressSse2_x86_64.inc
@@ -3,7 +3,7 @@
 // Same as SSSE3 but byte-swap uses SSE2 emulation (pshuflw/pshufhw + psrlw/psllw/por)
 // instead of SSSE3 pshufb. Message schedule expansion and compression use GPR only.
 // Expects MS x64 ABI: rcx = state ptr, rdx = data ptr, r8d = numblocks, r9 = K512 ptr.
-// K512 layout: 80 UInt64 round constants (640 bytes), BSWAP64 mask unused.
+// K512: 80 UInt64 round constants (640 bytes). SSE2 byte-swaps without a mask (4-param path).
 // Uses xmm0, xmm4, all GPR.
 //
 // Stack layout (sub rsp, 1016): same as SSSE3 version (xmm6-xmm7 save slots unused)

--- a/HashLib/src/Include/Simd/SHA512/SHA512CompressSsse3_i386.inc
+++ b/HashLib/src/Include/Simd/SHA512/SHA512CompressSsse3_i386.inc
@@ -1,8 +1,9 @@
 // SHA-512 SSSE3 implementation (IA-32).
 // Based on SHA512CompressSsse3_x86_64.inc (x86-64); same algorithm as SSE2 i386 but Phase 1 uses pshufb.
-// IA-32: after SimdProc4Begin_i386 — ebx = state, esi = data, edi = numblocks, eax = K512 ptr
-//   (parallel to MS x64 ABI: rcx, rdx, r8d, r9).
-// K512: 80 UInt64 round constants (640 bytes), BSWAP64 mask at offset 640 ($280).
+// IA-32: after SimdProc5Begin_i386 — ebx = state, esi = data, edi = numblocks,
+//   eax = K512 ptr (80 UInt64 round constants), ecx = BSWAP64 mask ptr (16 bytes)
+//   (parallel to MS x64 ABI: rcx, rdx, r8d, r9, r10).
+// maskptr saved to [esp+$34] in the prologue; reloaded (into eax) each block.
 // Phase 1: SSSE3 xmm0/xmm4/xmm7 (mask); ebx = W ring @ [esp+$2F0], ebp = W+K @ [esp+$70].
 // Phase 2: rax..r11 in [esp+880]..[esp+936] (8 qwords).
 // Scratch: expand [esp+$3B8]..$3E0; shrd [esp+1000]/[esp+1004]; and M,M [esp+1008]..1015.
@@ -18,16 +19,18 @@
   mov dword ptr [esp + $28], edi
   mov dword ptr [esp + $2C], eax
   mov dword ptr [esp + $30], ebp
+  mov dword ptr [esp + $34], ecx
 
   cmp dword ptr [esp + $28], 0
   jz @ssse3_512_done
 
 @ssse3_512_block_loop:
+  mov eax, dword ptr [esp + $34]
+  movdqu xmm7, oword ptr [eax]
   mov eax, dword ptr [esp + $2C]
   lea ebp, [esp + $70]
   lea ebx, [esp + $2F0]
   mov esi, dword ptr [esp + $24]
-  movdqu xmm7, oword ptr [eax + $280]
 
   movdqu xmm0, oword ptr [esi+$0]
   pshufb xmm0, xmm7

--- a/HashLib/src/Include/Simd/SHA512/SHA512CompressSsse3_x86_64.inc
+++ b/HashLib/src/Include/Simd/SHA512/SHA512CompressSsse3_x86_64.inc
@@ -1,6 +1,6 @@
 // SHA-512 SSSE3 implementation.
-// Expects MS x64 ABI: rcx = state ptr, rdx = data ptr, r8d = numblocks, r9 = K512 ptr.
-// K512 layout: 80 UInt64 round constants (640 bytes), then BSWAP64 mask (16 bytes) at offset 640.
+// Expects MS x64 ABI: rcx = state ptr, rdx = data ptr, r8d = numblocks,
+//   r9 = K512 ptr (80 UInt64 round constants), r10 = BSWAP64 mask ptr (16 bytes).
 // Uses xmm0-xmm7 (byte-swap only), all GPR.
 //
 // SSSE3 pshufb is used for the initial 128-byte big-endian to little-endian byte swap.
@@ -21,7 +21,7 @@
 //   [rsp +  80.. 87]: r14 save
 //   [rsp +  88.. 95]: r15 save
 //   [rsp +  96..103]: K512 ptr save
-//   [rsp + 104..111]: padding
+//   [rsp + 104..111]: BSWAP mask ptr save
 //   [rsp + 112..751]: W+K buffer (640 bytes = 80 * 8, 16-byte aligned)
 //   [rsp + 752..879]: W circular buffer (128 bytes = 16 * 8)
 
@@ -42,6 +42,7 @@
   mov r13, rdx
   mov r14d, r8d
   mov [rsp + $60], r9
+  mov [rsp + $68], r10
 
   test r14d, r14d
   jz @ssse3_512_done
@@ -50,8 +51,9 @@
 
   // ========== Phase 1: Load, byte-swap, expand message schedule ==========
 
+  mov rax, [rsp + $68]
+  movdqu xmm7, oword [rax]
   mov rax, [rsp + $60]
-  movdqu xmm7, oword [rax + $280]
 
   lea rbp, [rsp + $70]
   lea r15, [rsp + $2F0]


### PR DESCRIPTION
The x86 SIMD kernels previously appended a pshufb byte-swap mask to the end of the K256/K512/K_SHA1 round-constant arrays and reached it via an offset from the constants pointer (e.g. [r9+$100]). This conflated two unrelated things: the algorithm's round constants and an x86-only implementation detail, and it bloated the public K arrays with values that are not part of the SHA specification.
Separate the two concerns:
- Shrink K256 [0..63], K512 [0..79] and K_SHA1 [0..15] back to exactly the spec-defined round constants.
- Introduce dedicated BSWAP32_MASK / BSWAP64_MASK constants, guarded by {$IFDEF HASHLIB_X86_SIMD} since they are an x86 SIMD concern only (ARM byte-swaps natively via REV32/REV64 and needs no mask table).
- Pass the mask as a separate 5th pointer argument: the SSSE3/AVX2/SHA-NI compress procedures now use SimdProc5Begin instead of SimdProc4Begin, and the kernels load the mask from the dedicated pointer (r10 on x86-64, ecx on i386) instead of an offset past the constants. SSE2 backends are unchanged (they byte-swap without a mask).